### PR TITLE
Using fixed version 1.2.1 of Resolver

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -18,7 +18,7 @@ target 'Boardy_Example' do
   pod 'RIBs' , :git => 'https://github.com/uber/RIBs.git', :branch => 'master'
   pod 'ViewStateCore'
   pod 'SiFUtilities'
-  pod 'Resolver' , '~> 1.1'
+  pod 'Resolver' , '1.2.1'
 
   target 'Boardy_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Boardy (1.11.1):
-    - Boardy/Default (= 1.11.1)
-  - Boardy/Attachable (1.11.1):
+  - Boardy (1.14.1):
+    - Boardy/Default (= 1.14.1)
+  - Boardy/Attachable (1.14.1):
     - Boardy/Core
     - Boardy/DeepLink
-  - Boardy/ComponentKit (1.11.1):
+  - Boardy/ComponentKit (1.14.1):
     - Boardy/Core
-  - Boardy/Composable (1.11.1):
+  - Boardy/Composable (1.14.1):
     - Boardy/Core
     - UIComposable
-  - Boardy/Core (1.11.1)
-  - Boardy/DeepLink (1.11.1):
+  - Boardy/Core (1.14.1)
+  - Boardy/DeepLink (1.14.1):
     - Boardy/Core
-  - Boardy/Default (1.11.1):
+  - Boardy/Default (1.14.1):
     - Boardy/Attachable
     - Boardy/Core
-  - Boardy/RxStoreRef (1.11.1):
+  - Boardy/RxStoreRef (1.14.1):
     - Boardy/Core
     - Boardy/DeepLink
     - ReferenceStoreManager
@@ -36,52 +36,60 @@ PODS:
     - RxSwift
   - Resolver (1.2.1)
   - RIBs (0.9.3):
-    - RxRelay (~> 5.1)
-    - RxSwift (~> 5.1)
-  - RxCocoa (5.1.1):
-    - RxRelay (~> 5)
-    - RxSwift (~> 5)
-  - RxRelay (5.1.1):
-    - RxSwift (~> 5)
-  - RxSwift (5.1.1)
-  - SiFUtilities (4.10.0):
-    - SiFUtilities/Default (= 4.10.0)
-  - SiFUtilities/Core (4.10.0)
-  - SiFUtilities/Default (4.10.0):
-    - SiFUtilities/Core
+    - RxRelay (~> 6.0.0)
+    - RxSwift (~> 6.0.0)
+  - RxCocoa (6.0.0):
+    - RxRelay (= 6.0.0)
+    - RxSwift (= 6.0.0)
+  - RxRelay (6.0.0):
+    - RxSwift (= 6.0.0)
+  - RxSwift (6.0.0)
+  - SiFUtilities (4.17.1):
+    - SiFUtilities/Default (= 4.17.1)
+  - SiFUtilities/Default (4.17.1):
     - SiFUtilities/Endpoint
+    - SiFUtilities/Foundation
     - SiFUtilities/Helpers
     - SiFUtilities/IBDesignable
     - SiFUtilities/KeyValue
     - SiFUtilities/Loading
     - SiFUtilities/Localize
+    - SiFUtilities/Media
     - SiFUtilities/Nib
     - SiFUtilities/Runtime
     - SiFUtilities/Show
+    - SiFUtilities/UIKit
     - SiFUtilities/WeakObject
-  - SiFUtilities/Endpoint (4.10.0)
-  - SiFUtilities/Helpers (4.10.0)
-  - SiFUtilities/IBDesignable (4.10.0):
-    - SiFUtilities/Core
-  - SiFUtilities/KeyValue (4.10.0)
-  - SiFUtilities/Loading (4.10.0)
-  - SiFUtilities/Localize (4.10.0):
+  - SiFUtilities/Endpoint (4.17.1)
+  - SiFUtilities/Foundation (4.17.1)
+  - SiFUtilities/Helpers (4.17.1)
+  - SiFUtilities/IBDesignable (4.17.1):
+    - SiFUtilities/UIKit
+  - SiFUtilities/KeyValue (4.17.1)
+  - SiFUtilities/Loading (4.17.1)
+  - SiFUtilities/Localize (4.17.1):
     - Localize-Swift
-    - SiFUtilities/Core
+    - SiFUtilities/Foundation
     - SiFUtilities/Runtime
-  - SiFUtilities/Nib (4.10.0):
-    - SiFUtilities/Core
-  - SiFUtilities/Runtime (4.10.0)
-  - SiFUtilities/Show (4.10.0):
-    - SiFUtilities/Core
-  - SiFUtilities/WeakObject (4.10.0)
-  - UIComposable (0.4.1):
-    - UIComposable/Default (= 0.4.1)
-  - UIComposable/Core (0.4.1)
-  - UIComposable/Default (0.4.1):
+    - SiFUtilities/UIKit
+  - SiFUtilities/Media (4.17.1)
+  - SiFUtilities/Nib (4.17.1):
+    - SiFUtilities/Foundation
+  - SiFUtilities/Runtime (4.17.1)
+  - SiFUtilities/Show (4.17.1):
+    - SiFUtilities/UIKit
+  - SiFUtilities/UIKit (4.17.1)
+  - SiFUtilities/WeakObject (4.17.1)
+  - UIComposable (0.5.1):
+    - UIComposable/Default (= 0.5.1)
+  - UIComposable/Core (0.5.1)
+  - UIComposable/Default (0.5.1):
     - UIComposable/Core
-  - UIComposable/DiffUI (0.4.1):
+    - UIComposable/UIKit
+  - UIComposable/DiffUI (0.5.1):
     - DiffableDataSources
+    - UIComposable/Core
+  - UIComposable/UIKit (0.5.1):
     - UIComposable/Core
   - ViewStateCore (1.7.0)
 
@@ -91,7 +99,7 @@ DEPENDENCIES:
   - Boardy/Composable (from `../`)
   - Boardy/DeepLink (from `../`)
   - Boardy/RxStoreRef (from `../`)
-  - Resolver (~> 1.1)
+  - Resolver (= 1.2.1)
   - RIBs (from `https://github.com/uber/RIBs.git`, branch `master`)
   - SiFUtilities
   - UIComposable/DiffUI
@@ -120,24 +128,24 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   RIBs:
-    :commit: ffc489f00db785c8c0051678393f7aba0d52f1a4
+    :commit: 32ca504b7e58f1929bec7ae34101ec3f75a17127
     :git: https://github.com/uber/RIBs.git
 
 SPEC CHECKSUMS:
-  Boardy: afeb153c9cf07c0648f2903090dc41487f73748e
+  Boardy: d23f977dfe2551015bad0f5aff260326929cd699
   DiffableDataSources: 80396cec405c9b29e1e07b55c9be7d11b46c8741
   DifferenceKit: 516f12e336ed65a3a0665847b5c3cb5cad4bd4ea
   Localize-Swift: 6f4475136bdb0d7b2882ea3d4ea919d70142b232
   ReferenceStoreManager: f9b56c7eb783179e92ba39393fff362ca4937f10
   Resolver: 764e380b2ddb26bba48c6e45ab393c968894a156
-  RIBs: d4c4c7e7e4580f0bbe88bdc88b6c11704a738b7f
-  RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
-  RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
-  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
-  SiFUtilities: 34bf71c7f74942d70ce20498dd2d9f2308fd0dff
-  UIComposable: 784ec93c37caa67ae8145f4f57764b1cca314353
+  RIBs: dd8df1129289d51ed4fec6e2127613d9eaba204e
+  RxCocoa: 3f79328fafa3645b34600f37c31e64c73ae3a80e
+  RxRelay: 8d593be109c06ea850df027351beba614b012ffb
+  RxSwift: c14e798c59b9f6e9a2df8fd235602e85cc044295
+  SiFUtilities: 6e2b198ae66898a3ad05ec2b25a1632f570c9ac2
+  UIComposable: a002bab42cc52f8f71df1282fa4432583dd8c860
   ViewStateCore: 2f433a0e17e44edf36e90f52c0887d981c08d1a7
 
-PODFILE CHECKSUM: 22a85f280f23c7b36b593534739d39c598aba408
+PODFILE CHECKSUM: 6b3e4cd832925d912faf08fc08ca7e101e452347
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
# Description
`ResolverScopeApplication` is removed since version 1.3.0 of `Resolver`, so using optimistic operator on Resolver dep could cause the example project unbuildable.

# Solution
Using the highest version of Resolver which not contains this breaking change.