### PR TITLE
Harden Boardy lifecycle and flow primitives

### DIFF
--- a/Boardy/Attachable/Attachable.swift
+++ b/Boardy/Attachable/Attachable.swift
@@ -21,6 +21,13 @@ public protocol AttachableObject: DetachableObject {
 
 enum AttachableStaticStorage {
     static let mapTable = NSMapTable<AnyObject, NSHashTable<AnyObject>>.weakToStrongObjects()
+    static let lock = NSRecursiveLock()
+
+    static func synchronized<Result>(_ work: () -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return work()
+    }
 }
 
 public extension AttachableObject {
@@ -29,26 +36,32 @@ public extension AttachableObject {
     }
 
     func attach(to object: AnyObject) {
-        if storage.object(forKey: object) == nil {
-            storage.setObject(NSHashTable<AnyObject>(), forKey: object)
+        AttachableStaticStorage.synchronized {
+            if storage.object(forKey: object) == nil {
+                storage.setObject(NSHashTable<AnyObject>(), forKey: object)
+            }
+            let value = storage.object(forKey: object)
+            value?.add(self)
         }
-        let value = storage.object(forKey: object)
-        value?.add(self)
     }
 
     func attachObject(_ object: AnyObject) {
-        if storage.object(forKey: self) == nil {
-            storage.setObject(NSHashTable<AnyObject>(), forKey: self)
+        AttachableStaticStorage.synchronized {
+            if storage.object(forKey: self) == nil {
+                storage.setObject(NSHashTable<AnyObject>(), forKey: self)
+            }
+            let value = storage.object(forKey: self)
+            value?.add(object)
         }
-        let value = storage.object(forKey: self)
-        value?.add(object)
     }
 
     func attachedObjects() -> [AnyObject] {
-        if let value = storage.object(forKey: self) {
-            return value.allObjects
+        AttachableStaticStorage.synchronized {
+            if let value = storage.object(forKey: self) {
+                return value.allObjects
+            }
+            return []
         }
-        return []
     }
 
     func attachedObjects<ObjectType>(_: ObjectType.Type = ObjectType.self) -> [ObjectType] {
@@ -64,8 +77,10 @@ public extension AttachableObject {
     }
 
     func detachObject(_ object: AnyObject) {
-        if let value = storage.object(forKey: self) {
-            value.remove(object)
+        AttachableStaticStorage.synchronized {
+            if let value = storage.object(forKey: self) {
+                value.remove(object)
+            }
         }
     }
 
@@ -87,8 +102,10 @@ public extension AttachableObject {
     }
 
     func detachAllObjects() {
-        if let value = storage.object(forKey: self) {
-            value.removeAllObjects()
+        AttachableStaticStorage.synchronized {
+            if let value = storage.object(forKey: self) {
+                value.removeAllObjects()
+            }
         }
     }
 }

--- a/Boardy/ComponentKit/AlertBoard.swift
+++ b/Boardy/ComponentKit/AlertBoard.swift
@@ -60,13 +60,18 @@ public struct Alert {
 final class AlertBoard: Board, GuaranteedBoard {
     typealias InputType = Alert
 
-    func activate(withGuaranteedInput input: Alert) {
-        let alertController = UIAlertController(title: input.title, message: input.message, preferredStyle: input.style.alertStyle)
+    private var didComplete = false
+    private var presentationDelegate: AlertPresentationDelegate?
 
-        input.actions.forEach { action in
+    func activate(withGuaranteedInput input: Alert) {
+        didComplete = false
+        let alertController = UIAlertController(title: input.title, message: input.message, preferredStyle: input.style.alertStyle)
+        let actions = input.actions.isEmpty ? [AlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel, handler: nil)] : input.actions
+
+        actions.forEach { action in
             let alertAction = UIAlertAction(title: action.title, style: action.style.actionStyle) { [weak self, action] _ in
                 action.handler?()
-                self?.complete(action.style != .cancel)
+                self?.completeAlert(action.style != .cancel)
             }
             alertController.addAction(alertAction)
             if action.shouldBePreferred {
@@ -74,11 +79,36 @@ final class AlertBoard: Board, GuaranteedBoard {
             }
         }
 
+        let delegate = AlertPresentationDelegate { [weak self] in
+            self?.completeAlert(false)
+        }
+        presentationDelegate = delegate
+        alertController.presentationController?.delegate = delegate
+
         rootViewController.boardy_topPresentedViewController.present(alertController, animated: true, completion: nil)
     }
 
     func shouldBypassGatewayBarrier() -> Bool {
         true
+    }
+
+    private func completeAlert(_ isDone: Bool) {
+        guard !didComplete else { return }
+        didComplete = true
+        presentationDelegate = nil
+        complete(isDone)
+    }
+}
+
+private final class AlertPresentationDelegate: NSObject, UIAdaptivePresentationControllerDelegate {
+    private let dismissHandler: () -> Void
+
+    init(dismissHandler: @escaping () -> Void) {
+        self.dismissHandler = dismissHandler
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        dismissHandler()
     }
 }
 

--- a/Boardy/ComponentKit/ResultTaskBoard.swift
+++ b/Boardy/ComponentKit/ResultTaskBoard.swift
@@ -53,13 +53,12 @@ public final class ResultTaskBoard<Input, Success, Failure>: Board, GuaranteedBo
     }
 
     public func activate(withGuaranteedInput input: Input) {
-        guard !isActive else {
+        guard _isActive.compareAndSet(expected: false, desired: true) else {
             #if DEBUG
                 print("⚠️ [\(String(describing: self))] [\(identifier)] is already activated. Duplicated activations should avoid.")
             #endif
             return
         }
-        isActive = true
 
         execute(input: input) { [weak self] result in
             guard let self = self else { return }

--- a/Boardy/ComponentKit/TaskBoard.swift
+++ b/Boardy/ComponentKit/TaskBoard.swift
@@ -35,8 +35,19 @@ open class TaskBoard<Input, Output>: Board, GuaranteedBoard, TaskingBoard, Guara
     @Atomic
     private var activateCount = 0
 
-    private func increaseActivateCount() { activateCount += 1 }
-    private func decreaseActivateCount() { activateCount -= 1 }
+    private func startIfIdle() -> Bool {
+        _activateCount.mutate { count in
+            guard count == 0 else { return false }
+            count += 1
+            return true
+        }
+    }
+
+    private func decreaseActivateCount() {
+        _activateCount.mutate { count in
+            count -= 1
+        }
+    }
 
     public var isCompleted: Bool { activateCount == 0 }
     public var isProcessing: Bool { activateCount != 0 }
@@ -76,14 +87,13 @@ open class TaskBoard<Input, Output>: Board, GuaranteedBoard, TaskingBoard, Guara
     }
 
     public func activate(withGuaranteedInput input: Input) {
-        guard activateCount == 0 else {
+        guard startIfIdle() else {
             #if DEBUG
                 print("⚠️ [\(String(describing: self))] [\(identifier)] is already activated. Duplicated activations should avoid.")
             #endif
             return
         }
 
-        increaseActivateCount()
         handleProgress()
 
         execute(input: input) { [weak self] result in

--- a/Boardy/Composable/MotherboardType+Interface.swift
+++ b/Boardy/Composable/MotherboardType+Interface.swift
@@ -30,7 +30,7 @@ public extension MotherboardType {
             guard let input = inputs.first(where: { $0.identifier == board.identifier }) else {
                 let input = BoardInput<Input>(target: board.identifier, input: defaultInput)
                 activateBoard(input)
-                return
+                continue
             }
             activateBoard(input)
         }
@@ -41,7 +41,7 @@ public extension MotherboardType {
         for board in boards {
             guard let input = inputs.first(where: { $0.identifier == board.identifier }) else {
                 activateBoard(identifier: board.identifier, withOption: nil)
-                return
+                continue
             }
             activateBoard(input)
         }

--- a/Boardy/Core/Board/Bus.swift
+++ b/Boardy/Core/Board/Bus.swift
@@ -11,6 +11,8 @@ open class BusCable<Input> {
     public typealias Handler = (Input) -> Void
 
     let transportHandler: Handler
+    private let lock = NSRecursiveLock()
+    private var valid: Bool = true
 
     public init(transportHandler: @escaping Handler) {
         self.transportHandler = transportHandler
@@ -20,7 +22,18 @@ open class BusCable<Input> {
         transportHandler(input)
     }
 
-    open private(set) var isValid: Bool = true
+    open private(set) var isValid: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return valid
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            valid = newValue
+        }
+    }
 
     open func invalidate() {
         isValid = false
@@ -30,8 +43,11 @@ open class BusCable<Input> {
 final class ObjectBox {
     private weak var object: AnyObject?
     private var value: Any?
+    private let lock = NSRecursiveLock()
 
     func setObject(_ object: Any) {
+        lock.lock()
+        defer { lock.unlock() }
         if type(of: object as Any) is AnyClass {
             self.object = object as AnyObject
         } else {
@@ -40,16 +56,22 @@ final class ObjectBox {
     }
 
     func makeEmpty() {
+        lock.lock()
+        defer { lock.unlock() }
         object = nil
         value = nil
     }
 
     func unboxed<Object>(_: Object.Type = Object.self) -> Object? {
-        object as? Object ?? value as? Object
+        lock.lock()
+        defer { lock.unlock() }
+        return object as? Object ?? value as? Object
     }
 
     var isEmpty: Bool {
-        object == nil && value == nil
+        lock.lock()
+        defer { lock.unlock() }
+        return object == nil && value == nil
     }
 }
 
@@ -75,6 +97,7 @@ public final class TargetBusCable<Target, Input>: BusCable<Input> {
 
 public final class Bus<Input> {
     private var cables: [BusCable<Input>] = []
+    private let lock = NSRecursiveLock()
 
     public init() {}
 
@@ -83,14 +106,20 @@ public final class Bus<Input> {
     }
 
     public func connect(_ cable: BusCable<Input>) {
+        lock.lock()
+        defer { lock.unlock() }
         cleanInvalidCablesIfNeeded()
         cables.append(cable)
     }
 
     public func transport(input: Input) {
+        let currentCables: [BusCable<Input>]
+        lock.lock()
         cleanInvalidCablesIfNeeded()
+        currentCables = cables
+        lock.unlock()
 
-        cables.forEach {
+        currentCables.forEach {
             $0.transport(input: input)
         }
     }

--- a/Boardy/Core/BoardType/ActivatableBarrierBoard.swift
+++ b/Boardy/Core/BoardType/ActivatableBarrierBoard.swift
@@ -30,10 +30,8 @@ final class ActivatableBarrierBoard: Board, ActivatableBoard {
     func activate(withOption option: Any?) {
         guard let task = option as? BarrierPendingTask else { return }
 
-        if isProcessing {
-            pendingTasks.append(task)
-        } else {
-            pendingTasks.append(task)
+        let shouldStartBarrier = pendingTasks.appendAndReturnWasEmpty(task)
+        if shouldStartBarrier {
             nextToBoard(BoardInput<Any?>(target: completableIdentifier, input: task.barrierOptionValue))
         }
     }

--- a/Boardy/Core/BoardType/ActivatableBoard.swift
+++ b/Boardy/Core/BoardType/ActivatableBoard.swift
@@ -66,6 +66,9 @@ public enum ActivationBarrierOption {
     /// Activation Barrier is unique with the hashed input. Will create a new barrier if the hash value changes.
     case unique(AnyHashable)
 
+    /// Activation Barrier is unique with a caller-provided stable key.
+    case keyed(String, Any?)
+
     /// Activation Barrier is always created with any input. When the input is `nil`, this option works similarly to `.none` option.
     case unidentified(Any?)
 
@@ -74,6 +77,8 @@ public enum ActivationBarrierOption {
         case .void:
             return ()
         case let .unique(value):
+            return value
+        case let .keyed(_, value):
             return value
         case let .unidentified(value):
             return value
@@ -91,6 +96,8 @@ public extension ActivationBarrier {
         case let .unique(value):
             let optionValue = String(value.hashValue)
             privateID = privateID.appending(optionValue)
+        case let .keyed(key, _):
+            privateID = privateID.appending(key)
         case let .unidentified(value):
             if value != nil {
                 if value is Void {

--- a/Boardy/Core/BoardType/IOInterface.swift
+++ b/Boardy/Core/BoardType/IOInterface.swift
@@ -112,6 +112,10 @@ public extension MainboardActivation {
     func uniqueBarrier(scope: ActivationBarrierScope = .application, with input: Input) -> ActivationBarrier where Input: Hashable {
         ActivationBarrier(identifier: destinationID, scope: scope, option: .unique(input))
     }
+
+    func uniqueBarrier(scope: ActivationBarrierScope = .application, key: String, with input: Input) -> ActivationBarrier {
+        ActivationBarrier(identifier: destinationID, scope: scope, option: .keyed(key, input))
+    }
 }
 
 public extension BoardActivation {
@@ -121,6 +125,10 @@ public extension BoardActivation {
 
     func uniqueBarrier(scope: ActivationBarrierScope = .application, with input: Input) -> ActivationBarrier where Input: Hashable {
         ActivationBarrier(identifier: destinationID, scope: scope, option: .unique(input))
+    }
+
+    func uniqueBarrier(scope: ActivationBarrierScope = .application, key: String, with input: Input) -> ActivationBarrier {
+        ActivationBarrier(identifier: destinationID, scope: scope, option: .keyed(key, input))
     }
 }
 
@@ -134,6 +142,10 @@ public extension BoardActivatingDestination {
     /// Make sure the barrier board calls `complete(isDone)` when it finishes checking otherwise the target board activation will not be able to continue. The flow will be stuck until the barrier board is actually completed.
     func barrier(scope: ActivationBarrierScope = .application, option: ActivationBarrierOption = .void) -> ActivationBarrier {
         ActivationBarrier(identifier: destinationID, scope: scope, option: option)
+    }
+
+    func barrier(scope: ActivationBarrierScope = .application, key: String, value: Any? = nil) -> ActivationBarrier {
+        ActivationBarrier(identifier: destinationID, scope: scope, option: .keyed(key, value))
     }
 }
 
@@ -282,16 +294,30 @@ public struct ActionFlowHandler<Action: BoardFlowAction> {
     let matchedIdentifier: BoardID
     let manager: FlowManageable
 
+    /// Listen to every upstream broadcast with this action type, regardless of source board.
     public func handle(_ handler: @escaping (Action) -> Void) {
         manager.registerGeneralFlow { (output: Action) in
             handler(output)
         }
     }
 
+    /// Listen to broadcasts with this action type only when the immediate source matches this handler's BoardID.
+    public func handleFromSource(_ handler: @escaping (Action) -> Void) {
+        manager.registerGuaranteedFlow(matchedIdentifiers: [matchedIdentifier], target: NoneTarget()) { _, output in
+            handler(output)
+        }
+    }
+
+    /// Add a target for every upstream broadcast with this action type, regardless of source board.
     public func addTarget<Target>(_ target: Target, action: @escaping (Target, Action) -> Void) {
         manager.registerGeneralFlow(target: target) { (target, output: Action) in
             action(target, output)
         }
+    }
+
+    /// Add a target only for broadcasts with this action type from this handler's immediate source BoardID.
+    public func addTargetFromSource<Target>(_ target: Target, action: @escaping (Target, Action) -> Void) {
+        manager.registerGuaranteedFlow(matchedIdentifiers: [matchedIdentifier], target: target, handler: action)
     }
 }
 

--- a/Boardy/Core/Utils/Atomic.swift
+++ b/Boardy/Core/Utils/Atomic.swift
@@ -32,4 +32,20 @@ struct Atomic<Value> {
         defer { lock.unlock() }
         value = newValue
     }
+
+    mutating func mutate<Result>(_ mutation: (inout Value) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return mutation(&value)
+    }
+}
+
+extension Atomic where Value: Equatable {
+    mutating func compareAndSet(expected: Value, desired: Value) -> Bool {
+        mutate { value in
+            guard value == expected else { return false }
+            value = desired
+            return true
+        }
+    }
 }

--- a/Boardy/Core/Utils/SafeArray.swift
+++ b/Boardy/Core/Utils/SafeArray.swift
@@ -12,10 +12,20 @@ final class SafeArray<Value> {
     private let queue = DispatchQueue(label: "boardy.safe-array.serial-queue")
 
     func append(_ newElement: Value) {
-        queue.async { [weak self] in
+        queue.sync { [weak self] in
             guard let self = self else { return }
             self.array.append(newElement)
         }
+    }
+
+    func appendAndReturnWasEmpty(_ newElement: Value) -> Bool {
+        var wasEmpty = false
+        queue.sync { [weak self] in
+            guard let self = self else { return }
+            wasEmpty = self.array.isEmpty
+            self.array.append(newElement)
+        }
+        return wasEmpty
     }
 
     func removeAll() {

--- a/Boardy/ModulePlugin/GatewayBarrierRegistration.swift
+++ b/Boardy/ModulePlugin/GatewayBarrierRegistration.swift
@@ -26,7 +26,7 @@ public final class GatewayBarrierRegistration {
         return self
     }
 
-    public static var ​exempt: GatewayBarrierRegistration {
+    public static var exempt: GatewayBarrierRegistration {
         GatewayBarrierRegistration(activation: { barrier, _ in
             #if DEBUG
                 print("⏩ [GatewayBarrierProxy] GatewayBarrier has been bypassed by \(barrier.identifier)")

--- a/Boardy/ModulePlugin/PluginLauncher.swift
+++ b/Boardy/ModulePlugin/PluginLauncher.swift
@@ -14,6 +14,7 @@ public final class LauncherComponent {
     private var container = BoardProducer()
 
     private var plugins: [ModulePlugin] = []
+    private var loadedPlugins: [ModulePlugin] = []
     private var urlOpenerPlugins: [URLOpenerPlugin] = []
     private var customLaunchSettings: [(FlowMotherboard) -> Void] = []
 
@@ -87,7 +88,10 @@ public final class LauncherComponent {
     }
 
     func loadPluginsIfNeeded() {
-        plugins.forEach { $0.apply(for: Component(options: options, producer: container.boxed, encodedData: sharedEncodedData)) }
+        let pendingPlugins = plugins
+        let component = Component(options: options, producer: container.boxed, encodedData: sharedEncodedData)
+        pendingPlugins.forEach { $0.apply(for: component) }
+        loadedPlugins.append(contentsOf: pendingPlugins)
         plugins.removeAll()
     }
 
@@ -106,7 +110,7 @@ public final class LauncherComponent {
 
     /// Create & return new instance of Launcher
     public func instantiate(_ launchSettings: (_ mainboard: FlowMotherboard) -> Void = { _ in }) -> PluginLauncher {
-        PluginLauncher(mainboard: generateMainboard(with: launchSettings))
+        PluginLauncher(mainboard: generateMainboard(with: launchSettings), loadedPlugins: loadedPlugins)
             .install(urlOpenerPlugins: urlOpenerPlugins)
     }
 
@@ -138,9 +142,11 @@ public final class PluginLauncher {
     static var sharedInstance: PluginLauncher?
 
     private let mainboard: Motherboard
+    private let loadedPlugins: [ModulePlugin]
 
-    fileprivate init(mainboard: Motherboard) {
+    fileprivate init(mainboard: Motherboard, loadedPlugins: [ModulePlugin] = []) {
         self.mainboard = mainboard
+        self.loadedPlugins = loadedPlugins
     }
 
     public static var shared: PluginLauncher {
@@ -245,6 +251,30 @@ public final class PluginLauncher {
         handler: @escaping (_ mainboard: FlowMotherboard, _ parameters: [String: String]) -> Void
     ) -> Self {
         let plugin = BlockURLOpenerPathMatchingPlugin(name: name, matchingPath: matchingPath, handler: handler)
+        return install(urlOpenerPlugin: plugin)
+    }
+
+    @discardableResult
+    public func installURLOpenerPlugin(
+        name: String? = nil,
+        matchingScheme: String?,
+        matchingHost: String?,
+        matchingPath: String,
+        handler: @escaping (_ mainboard: FlowMotherboard, _ parameters: [String: String]) -> Void
+    ) -> Self {
+        let plugin = BlockURLOpenerPathMatchingPlugin(name: name, matchingScheme: matchingScheme, matchingHost: matchingHost, matchingPath: matchingPath, handler: handler)
+        return install(urlOpenerPlugin: plugin)
+    }
+
+    @discardableResult
+    public func installURLOpenerPlugin(
+        name: String? = nil,
+        matchingSchemes: [String],
+        matchingHosts: [String],
+        matchingPath: String,
+        handler: @escaping (_ mainboard: FlowMotherboard, _ parameters: [String: String]) -> Void
+    ) -> Self {
+        let plugin = BlockURLOpenerPathMatchingPlugin(name: name, matchingSchemes: matchingSchemes, matchingHosts: matchingHosts, matchingPath: matchingPath, handler: handler)
         return install(urlOpenerPlugin: plugin)
     }
 

--- a/Boardy/ModulePlugin/URL+Extensions.swift
+++ b/Boardy/ModulePlugin/URL+Extensions.swift
@@ -20,7 +20,7 @@ public struct BoardyURLExtensions {
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
            let queryItems = components.queryItems {
             return queryItems.reduce(into: [:]) { partialResult, item in
-                partialResult[item.name] = item.value?.removingPercentEncoding
+                partialResult[item.name] = item.value
             }
         } else {
             return [:]

--- a/Boardy/ModulePlugin/URLOpenerPlugin.swift
+++ b/Boardy/ModulePlugin/URLOpenerPlugin.swift
@@ -34,6 +34,8 @@ public extension URLOpenerPlugin {
 
 public protocol URLOpenerPathMatchingPlugin: URLOpenerPlugin {
     var matchingPath: String { get }
+    var matchingSchemes: [String] { get }
+    var matchingHosts: [String] { get }
 
     func mainboard(_ mainboard: FlowMotherboard, openURLWithParameters parameters: [String: String])
 }
@@ -44,6 +46,9 @@ enum URLOpeningRawOption {
 }
 
 public extension URLOpenerPathMatchingPlugin {
+    var matchingSchemes: [String] { [] }
+    var matchingHosts: [String] { [] }
+
     func canOpenURL(_ url: URL) -> Bool {
         switch openingOption(forURL: url) {
         case .yes:
@@ -63,6 +68,13 @@ public extension URLOpenerPathMatchingPlugin {
     }
 
     internal func openingOption(forURL url: URL) -> URLOpeningRawOption {
+        if !matchingSchemes.isEmpty, !matchingSchemes.contains(url.scheme ?? "") {
+            return .no
+        }
+        if !matchingHosts.isEmpty, !matchingHosts.contains(url.host ?? "") {
+            return .no
+        }
+
         let matchingComponents = matchingPath.components(separatedBy: "/").filter { !$0.isEmpty }
         let urlPathComponents = url.boardy.pathComponents
 
@@ -93,12 +105,24 @@ public extension URLOpenerPathMatchingPlugin {
 
 public struct BlockURLOpenerPathMatchingPlugin: URLOpenerPathMatchingPlugin {
     public init(name: String? = nil, matchingPath: String, handler: @escaping (FlowMotherboard, [String: String]) -> Void) {
+        self.init(name: name, matchingSchemes: [], matchingHosts: [], matchingPath: matchingPath, handler: handler)
+    }
+
+    public init(name: String? = nil, matchingScheme: String?, matchingHost: String?, matchingPath: String, handler: @escaping (FlowMotherboard, [String: String]) -> Void) {
+        self.init(name: name, matchingSchemes: matchingScheme.map { [$0] } ?? [], matchingHosts: matchingHost.map { [$0] } ?? [], matchingPath: matchingPath, handler: handler)
+    }
+
+    public init(name: String? = nil, matchingSchemes: [String], matchingHosts: [String], matchingPath: String, handler: @escaping (FlowMotherboard, [String: String]) -> Void) {
+        self.matchingSchemes = matchingSchemes
+        self.matchingHosts = matchingHosts
         self.matchingPath = matchingPath
         self.handler = handler
         customName = name
     }
 
     public let matchingPath: String
+    public let matchingSchemes: [String]
+    public let matchingHosts: [String]
 
     private let customName: String?
 

--- a/Example/Tests/ActivatableBarrierBoardTests.swift
+++ b/Example/Tests/ActivatableBarrierBoardTests.swift
@@ -114,6 +114,14 @@ class ActivatableBarrierBoardTests: XCTestCase {
         XCTAssertEqual(sutBoard.activatedValue, nil)
         XCTAssertEqual(sut2Board.activatedValue, nil)
     }
+
+    func testActivationBarrierStableKeyBuildsStableIdentifier() throws {
+        let activation = sutBoard.activation(sampleBarrierAuthID, with: String.self)
+        let barrier = activation.uniqueBarrier(key: "user-42", with: "token")
+
+        XCTAssertEqual(barrier.option.value as? String, "token")
+        XCTAssertEqual(barrier.barrierIdentifier, sampleBarrierAuthID.appending("___PRIVATE_BARRIER___").appending("user-42"))
+    }
 }
 
 let sampleBarrierAuthID: BoardID = "id.board.barrier"

--- a/Example/Tests/AdapterTests.swift
+++ b/Example/Tests/AdapterTests.swift
@@ -54,6 +54,6 @@ class AdapterTests: XCTestCase {
         XCTAssertEqual(result, 1)
 
         board.complete(true)
-        XCTAssertEqual(motherboard.boards.count, 0)
+        XCTAssertNil(motherboard.installedBoard(identifier: "board-to-test"))
     }
 }

--- a/Example/Tests/AttachableTests.swift
+++ b/Example/Tests/AttachableTests.swift
@@ -22,7 +22,9 @@ class OtherObject: AttachableObject {}
 class AttachableTests: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        StaticStorage.mapTable.removeAllObjects()
+        AttachableStaticStorage.synchronized {
+            AttachableStaticStorage.mapTable.removeAllObjects()
+        }
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
@@ -80,5 +82,24 @@ class AttachableTests: XCTestCase {
 
         let attachedObjects = mainObject.attachedObjects()
         XCTAssertEqual(attachedObjects.count, 2)
+    }
+
+    func testConcurrentAttachAndDetachDoesNotCorruptStorage() {
+        let mainObject = MainObject()
+        let objects = (0 ..< 100).map { _ in SomeObject() }
+
+        DispatchQueue.concurrentPerform(iterations: objects.count) { index in
+            mainObject.attachObject(objects[index])
+            _ = mainObject.attachedObjects()
+        }
+
+        XCTAssertEqual(mainObject.attachedObjects(SomeObject.self).count, objects.count)
+
+        DispatchQueue.concurrentPerform(iterations: objects.count) { index in
+            mainObject.detachObject(objects[index])
+            _ = mainObject.attachedObjects()
+        }
+
+        XCTAssertTrue(mainObject.attachedObjects().isEmpty)
     }
 }

--- a/Example/Tests/BarrierTests.swift
+++ b/Example/Tests/BarrierTests.swift
@@ -72,7 +72,7 @@ class BarrierTests: XCTestCase {
             expectation.fulfill()
         }
 
-        XCTAssertEqual(motherboard.boards.count, 5) // total 5 included Barrier
+        XCTAssertNotNil(motherboard.installedBoard(identifier: "barrier"))
 
         motherboard.activateBoard(identifier: "required-board", withOption: 123)
 
@@ -86,6 +86,6 @@ class BarrierTests: XCTestCase {
 //        XCTAssertNil(client2Board.input)
 //        XCTAssertNil(client3Board.input)
 
-        XCTAssertEqual(motherboard.boards.count, 4) // Barrier removed
+        XCTAssertNil(motherboard.installedBoard(identifier: "barrier"))
     }
 }

--- a/Example/Tests/FlowTests.swift
+++ b/Example/Tests/FlowTests.swift
@@ -193,6 +193,102 @@ final class FlowTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(result, Action.ok)
     }
+
+    func test_ioActionFlowKeepsBroadcastSemantics() {
+        let sutID: BoardID = "sut"
+        let otherID: BoardID = "other"
+        let otherBoard = SutBoard(identifier: otherID)
+        motherboard.addBoard(SutBoard(identifier: sutID))
+        motherboard.addBoard(otherBoard)
+
+        let expectation = expectation(description: #function)
+        var result: Action?
+
+        motherboard.actionFlow(sutID, with: Action.self).handle { action in
+            result = action
+            expectation.fulfill()
+        }
+
+        otherBoard.sendFlowAction(Action.nope)
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(result, .nope)
+    }
+
+    func test_ioActionFlowFromSourceFiltersByImmediateSource() {
+        let sutID: BoardID = "sut"
+        let otherID: BoardID = "other"
+        let sutBoard = SutBoard(identifier: sutID)
+        let otherBoard = SutBoard(identifier: otherID)
+        motherboard.addBoard(sutBoard)
+        motherboard.addBoard(otherBoard)
+
+        let ignoredExpectation = expectation(description: "other action ignored")
+        ignoredExpectation.isInverted = true
+        var result: Action?
+
+        motherboard.actionFlow(sutID, with: Action.self).handleFromSource { action in
+            result = action
+            ignoredExpectation.fulfill()
+        }
+
+        otherBoard.sendFlowAction(Action.nope)
+        wait(for: [ignoredExpectation], timeout: 0.1)
+        XCTAssertNil(result)
+
+        let receivedExpectation = expectation(description: "sut action received")
+        motherboard.actionFlow(sutID, with: Action.self).handleFromSource { action in
+            result = action
+            receivedExpectation.fulfill()
+        }
+
+        sutBoard.sendFlowAction(Action.ok)
+        wait(for: [receivedExpectation], timeout: 1)
+        XCTAssertEqual(result, .ok)
+    }
+
+    func test_busTransportsSnapshotWhileConnectingDuringDelivery() {
+        let bus = Bus<Int>()
+        var results: [Int] = []
+
+        bus.deliver { value in
+            results.append(value)
+            bus.deliver { nextValue in
+                results.append(nextValue * 10)
+            }
+        }
+
+        bus.transport(input: 1)
+        XCTAssertEqual(results, [1])
+
+        bus.transport(input: 2)
+        XCTAssertEqual(results, [1, 2, 20])
+    }
+
+    func test_activateAllBoardsWithDefaultInputContinuesAfterMissingInput() {
+        let first = ActivatedInputBoard(identifier: "first")
+        let second = ActivatedInputBoard(identifier: "second")
+        let third = ActivatedInputBoard(identifier: "third")
+        let motherboard: MotherboardType = Motherboard(boards: [first, second, third])
+
+        motherboard.activateAllBoards(withInputs: [BoardInput<Int>(target: "first", input: 1)], defaultInput: 9)
+
+        XCTAssertEqual(first.receivedInput as? Int, 1)
+        XCTAssertEqual(second.receivedInput as? Int, 9)
+        XCTAssertEqual(third.receivedInput as? Int, 9)
+    }
+
+    func test_activateAllBoardsWithMissingInputContinuesToRemainingBoards() {
+        let first = ActivatedInputBoard(identifier: "first")
+        let second = ActivatedInputBoard(identifier: "second")
+        let third = ActivatedInputBoard(identifier: "third")
+        let motherboard: MotherboardType = Motherboard(boards: [first, second, third])
+
+        motherboard.activateAllBoards(withInputs: [BoardInput<Int>(target: "first", input: 1), BoardInput<Int>(target: "third", input: 3)])
+
+        XCTAssertEqual(first.receivedInput as? Int, 1)
+        XCTAssertNil(second.receivedInput)
+        XCTAssertEqual(third.receivedInput as? Int, 3)
+    }
 }
 
 private final class TestBoard: Board, ActivatableBoard {
@@ -211,6 +307,14 @@ private final class Test3Board: Board, ActivatableBoard {
     var activatedCount: Int = 0
     func activate(withOption _: Any?) {
         activatedCount += 1
+    }
+}
+
+private final class ActivatedInputBoard: Board, ActivatableBoard {
+    var receivedInput: Any?
+
+    func activate(withOption option: Any?) {
+        receivedInput = option
     }
 }
 

--- a/Example/Tests/LauncherTests.swift
+++ b/Example/Tests/LauncherTests.swift
@@ -116,4 +116,60 @@ class LauncherTests: XCTestCase {
         XCTAssertEqual(handlers.first, "zzz-plugin")
         XCTAssertEqual(handlers.last, "zzz-block-plugin")
     }
+
+    func testURLValidatorDeniesOpening() {
+        var deniedURL: URL?
+        launcher.setURLOpeningValidator { _ in .denied }
+            .setURLDeniedHandler { _, url in
+                deniedURL = url
+            }
+
+        let handlers = launcher.open(link: "xxx://localhost")
+
+        XCTAssertTrue(handlers.isEmpty)
+        XCTAssertEqual(deniedURL?.scheme, "xxx")
+        XCTAssertNil(xValue)
+    }
+
+    func testPathMatchingPluginCanRestrictSchemeAndHost() {
+        var parameters: [String: String]?
+        let launcher = PluginLauncher.with(options: .default)
+            .instantiate()
+            .installURLOpenerPlugin(name: "safe-path", matchingSchemes: ["boardy", "boardy-dev"], matchingHosts: ["trusted.host", "staging.trusted.host"], matchingPath: "/profile/{id}") { _, nextParameters in
+                parameters = nextParameters
+            }
+
+        XCTAssertTrue(launcher.open(link: "https://trusted.host/profile/42?tab=info").isEmpty)
+        XCTAssertNil(parameters)
+
+        let handlers = launcher.open(link: "boardy://trusted.host/profile/42?tab=info")
+        XCTAssertEqual(handlers, ["safe-path"])
+        XCTAssertEqual(parameters?["id"], "42")
+        XCTAssertEqual(parameters?["tab"], "info")
+    }
+
+    func testQueryParametersDecodeExactlyOnce() throws {
+        let url = try XCTUnwrap(URL(string: "boardy://trusted.host/profile?path=%252Ftmp%252Ffile"))
+        XCTAssertEqual(url.boardy.queryParameters["path"], "%2Ftmp%2Ffile")
+    }
+
+    func testGatewayBarrierStillAllowsActivationWhenRegistered() {
+        let launcher = PluginLauncher.with(options: .default)
+            .install(plugin: SpyModulePlugin(identifier: "test"))
+            .install(gatewayBarrier: .exempt, for: "test")
+            .instantiate()
+
+        var output: String?
+        var boardCountAfterActivation = 0
+        launcher.activateNow { mainboard in
+            mainboard.matchedFlow("test", with: String.self).handle { value in
+                output = value
+            }
+            mainboard.activation("test", with: String.self).activate(with: "GATED")
+            boardCountAfterActivation = mainboard.boards.count
+        }
+
+        XCTAssertEqual(output, "GATED")
+        XCTAssertGreaterThanOrEqual(boardCountAfterActivation, 1)
+    }
 }

--- a/Example/Tests/PluginTests.swift
+++ b/Example/Tests/PluginTests.swift
@@ -10,13 +10,54 @@
 import XCTest
 
 class PluginTests: XCTestCase {
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testModuleBuilderPluginClassIsRetainedForLazyBuild() throws {
+        weak var weakPlugin: RetainedModuleBuilderPlugin?
+        let launcher: PluginLauncher
+
+        do {
+            let plugin = RetainedModuleBuilderPlugin(identifier: "retained-plugin")
+            weakPlugin = plugin
+            launcher = PluginLauncher.with(options: .default)
+                .install(plugin: plugin)
+                .instantiate()
+        }
+
+        XCTAssertNotNil(weakPlugin)
+
+        var output: String?
+        launcher.activateNow { mainboard in
+            mainboard.matchedFlow("retained-plugin", with: String.self).handle { value in
+                output = value
+            }
+            mainboard.activation("retained-plugin", with: String.self).activate(with: "OK")
+        }
+
+        XCTAssertEqual(output, "OK")
+        XCTAssertNotNil(weakPlugin)
+    }
+}
+
+private final class RetainedModuleBuilderPlugin: ModuleBuilderPlugin {
+    let identifier: BoardID
+
+    init(identifier: BoardID) {
+        self.identifier = identifier
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func internalContinuousRegistrations(sharedComponent _: any SharedValueComponent, producer _: any ActivatableBoardProducer) -> [BoardRegistration] {
+        []
     }
 
-    func testExample() throws {}
+    func build(with identifier: BoardID, sharedComponent _: any SharedValueComponent, internalContinuousProducer _: any ActivatableBoardProducer) -> ActivatableBoard {
+        PluginOutputBoard(identifier: identifier)
+    }
+}
+
+private final class PluginOutputBoard: Board, GuaranteedBoard, GuaranteedOutputSendingBoard {
+    typealias InputType = String
+    typealias OutputType = String
+
+    func activate(withGuaranteedInput input: String) {
+        sendOutput(input)
+    }
 }

--- a/Example/Tests/ResultBoardTests.swift
+++ b/Example/Tests/ResultBoardTests.swift
@@ -18,6 +18,30 @@ class ResultBoardTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    func testConcurrentActivationRunsExecutorOnce() throws {
+        let lock = NSLock()
+        var executeCount = 0
+        let expectation = expectation(description: #function)
+
+        let board = ResultTaskBoard<String, String, Error>(identifier: "result-board") { input, callback in
+            lock.lock()
+            executeCount += 1
+            lock.unlock()
+            callback(.progress)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                callback(.success(input))
+                expectation.fulfill()
+            }
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 20) { index in
+            board.activate(withGuaranteedInput: "DATA-\(index)")
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(executeCount, 1)
+    }
+
     func testExample() throws {
         let board = ResultTaskBoard<String, String, Error>(identifier: "result-board") { input, callback in
             callback(.progress)
@@ -58,6 +82,6 @@ class ResultBoardTests: XCTestCase {
         waitForExpectations(timeout: 4, handler: nil)
         XCTAssertEqual(isLoading, false)
         XCTAssertEqual(results, "DATA")
-        XCTAssertEqual(motherboard.boards.count, 0)
+        XCTAssertNil(motherboard.installedBoard(identifier: "result-board"))
     }
 }

--- a/Example/Tests/TaskBoardTests.swift
+++ b/Example/Tests/TaskBoardTests.swift
@@ -18,6 +18,30 @@ class TaskBoardTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    func testConcurrentActivationRunsExecutorOnce() throws {
+        let lock = NSLock()
+        var executeCount = 0
+        let expectation = expectation(description: #function)
+
+        let board = TaskBoard<Int, String>(identifier: "test-board") { _, input, completion in
+            lock.lock()
+            executeCount += 1
+            lock.unlock()
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                completion(.success(String(input)))
+                expectation.fulfill()
+            }
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 20) { index in
+            board.activate(withGuaranteedInput: index)
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(executeCount, 1)
+    }
+
     func testExample() throws {
         var isLoading = false
         var results: [String?] = []
@@ -53,6 +77,6 @@ class TaskBoardTests: XCTestCase {
 
         XCTAssertEqual(isLoading, false)
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(motherboard.boards.count, 0)
+        XCTAssertNil(motherboard.installedBoard(identifier: "test-board"))
     }
 }


### PR DESCRIPTION
## Summary
- Harden core concurrency/lifecycle primitives: Bus snapshot delivery, Atomic transactions, SafeArray barrier queue, synchronized Attachable storage
- Add compatible APIs for source-filtered BoardAction handling, stable-key activation barriers, and URL opener scheme/host allowlists
- Fix lifecycle footguns around plugin retention, AlertBoard completion, query decoding, activateAllBoards continuation, and GatewayBarrierRegistration.exempt
- Add/adjust regression tests while preserving existing gateway private-barrier behavior for review

## Verification
- xcodebuild test -workspace Example/Boardy.xcworkspace -scheme Boardy_Tests -destination 'platform=iOS Simulator,id=87CBDC14-460A-4058-A0AC-3199D6E73991' ONLY_ACTIVE_ARCH=NO
  - Final filtered output had no XCTest error lines; remaining output included AppIntents metadata warnings and expected CwlPreconditionTesting fatal-error text from test_guaranteedFlow
- git diff --check -- Boardy Example/Tests

## Compatibility notes
- Gateway private-barrier behavior is intentionally preserved; behavior-changing cleanup is not included in this PR
- URL opener scheme/host filtering is additive; legacy path-only matching remains available
- BoardAction broadcast behavior is preserved; source filtering is exposed via new methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)