### PR TITLE
Stop barrier flows and destinations from outliving their owners

### DIFF
--- a/Boardy/Core/Board/Bus.swift
+++ b/Boardy/Core/Board/Bus.swift
@@ -118,12 +118,18 @@ public final class Bus<Input> {
 
     /// Delivers `input` to every valid cable, in connection order.
     ///
-    /// - Important: do not connect to or invalidate this bus from inside a handler; see the note on
-    ///   ``Bus``.
+    /// A handler may connect to or invalidate cables on this bus. Delivery iterates the set of
+    /// cables as it stood when the transport began, so a cable connected from inside a handler
+    /// starts receiving from the *next* transport rather than the current one.
     public func transport(input: Input) {
         cleanInvalidCablesIfNeeded()
 
-        cables.forEach {
+        // Iterate an explicit snapshot. Reading `cables` already yields a copy today — `Bus` is a
+        // class, so the property get hands back a copy-on-write value rather than a long-term
+        // borrow — but relying on that leaves the re-entrancy guarantee resting on an
+        // implementation detail of property access. Naming the snapshot makes it a decision.
+        let snapshot = cables
+        snapshot.forEach {
             $0.transport(input: input)
         }
     }

--- a/Boardy/Core/BoardType/ActivatableBarrierBoard.swift
+++ b/Boardy/Core/BoardType/ActivatableBarrierBoard.swift
@@ -288,6 +288,30 @@ final class ActivatableBarrierBoard: Board, ActivatableBoard {
         "boardy.barrier.completion.\(identifier.rawValue)"
     }
 
+    /// Takes the completion flow back off `owner`.
+    ///
+    /// A barrier board removes itself when its gate completes, but the flow it registered lives on
+    /// the owner and outlives it. Reopening the same gate builds a fresh barrier board that
+    /// registers the flow again, so without this every cycle leaves one dead flow behind — and the
+    /// owner filters all of them on every board message.
+    private func unregisterCompletableFlow(from owner: BarrierOwningMotherboard) {
+        let identity = ObjectIdentifier(owner)
+
+        let flowIdentifier = registrations.withLock { registrations -> String? in
+            guard var registration = registrations[identity],
+                  let flowIdentifier = registration.flowIdentifier
+            else {
+                return nil
+            }
+            registration.flowIdentifier = nil
+            registrations[identity] = registration
+            return flowIdentifier
+        }
+
+        guard let flowIdentifier else { return }
+        owner.removeFlow(by: flowIdentifier)
+    }
+
     /// Reports activations the barrier dropped because their owning motherboard went away.
     ///
     /// From the caller's side a discarded task is indistinguishable from one that simply never
@@ -347,6 +371,7 @@ final class ActivatableBarrierBoard: Board, ActivatableBoard {
         }
 
         complete()
+        unregisterCompletableFlow(from: owner)
 
         if isDone {
             transition.tasks.forEach { task in
@@ -430,6 +455,8 @@ final class ActivatableBarrierBoard: Board, ActivatableBoard {
     private func removeExactInstallation(
         from owner: BarrierOwningMotherboard
     ) {
+        unregisterCompletableFlow(from: owner)
+
         let containsSelf = owner.boards.contains { board in
             (board as AnyObject) === self
         }

--- a/Boardy/Core/BoardType/IOInterface+Destination.swift
+++ b/Boardy/Core/BoardType/IOInterface+Destination.swift
@@ -10,11 +10,25 @@ import Foundation
 public class MainboardDestination {
     public init(destinationID: BoardID, mainboard: any FlowMotherboard) {
         self.destinationID = destinationID
-        self.mainboard = mainboard
+        mainboardBox.setObject(mainboard)
     }
 
     public let destinationID: BoardID
-    let mainboard: FlowMotherboard
+
+    private let mainboardBox = ObjectBox()
+
+    /// The motherboard is held weakly.
+    ///
+    /// A destination is meant to be stored — that is the point of the type — and the natural place
+    /// to store it is the motherboard it came from, or one of its boards. Holding it strongly makes
+    /// that shape a retain cycle, and every other reference in this framework (`ObjectBox`,
+    /// `ContentBox`, `BarrierOwnerToken`, `BoardProducerBox`) is already weak.
+    ///
+    /// Once the motherboard is gone the destination becomes inert: it answers with a detached
+    /// stand-in, so sending through it does nothing instead of trapping.
+    var mainboard: FlowMotherboard {
+        mainboardBox.unboxed(FlowMotherboard.self) ?? DetachedDestination.makeMotherboard()
+    }
 }
 
 public extension MotherboardType where Self: FlowManageable {
@@ -74,11 +88,20 @@ public final class MainboardGenericDestination<Input, Output, Command, Action: B
 public class BoardDestination {
     public init(destinationID: BoardID, source: any ActivatableBoard) {
         self.destinationID = destinationID
-        self.source = source
+        sourceBox.setObject(source)
     }
 
     public let destinationID: BoardID
-    let source: ActivatableBoard
+
+    private let sourceBox = ObjectBox()
+
+    /// The source board is held weakly; see ``MainboardDestination/mainboard`` for why.
+    ///
+    /// Once the source is gone the destination becomes inert: it answers with a detached stand-in
+    /// that has no motherboard, so messages sent through it go nowhere.
+    var source: ActivatableBoard {
+        sourceBox.unboxed(ActivatableBoard.self) ?? DetachedDestination.makeBoard()
+    }
 }
 
 public extension ActivatableBoard {
@@ -112,5 +135,45 @@ public extension BoardDestination {
 
     var completer: BoardCompleter {
         source.completer(destinationID)
+    }
+}
+
+// MARK: - Detached stand-ins
+
+/// Answers every identifier with a board that does nothing.
+///
+/// A detached motherboard must not fall back to `NoBoardProducer`: that answers with a ``NoBoard``,
+/// which presents a "feature not found" alert and traps in DEBUG when it has no context. Sending
+/// through a dead destination should be silent, not fatal.
+private final class InertBoard: Board, ActivatableBoard {
+    func activate(withOption _: Any?) {}
+}
+
+private final class InertBoardProducer: ActivatableBoardProducer {
+    func produceBoard(identifier: BoardID) -> ActivatableBoard? {
+        InertBoard(identifier: identifier)
+    }
+
+    func produceGatewayBoard(identifier _: BoardID) -> ActivatableBoard? {
+        nil
+    }
+
+    func matchBoard(withIdentifier _: BoardID, to anotherIdentifier: BoardID) -> ActivatableBoard? {
+        InertBoard(identifier: anotherIdentifier)
+    }
+}
+
+private enum DetachedDestination {
+    static let boardIdentifier: BoardID = "boardy.detached-destination-source"
+
+    /// Stand-in source for a destination whose board is gone. It has no motherboard, so anything
+    /// sent through it goes nowhere.
+    static func makeBoard() -> ActivatableBoard {
+        InertBoard(identifier: boardIdentifier)
+    }
+
+    /// Stand-in for a destination whose motherboard is gone.
+    static func makeMotherboard() -> FlowMotherboard {
+        Motherboard(identifier: boardIdentifier, boardProducer: InertBoardProducer())
     }
 }

--- a/Example/Tests/ActivatableBarrierBoardTests.swift
+++ b/Example/Tests/ActivatableBarrierBoardTests.swift
@@ -11,6 +11,13 @@ import XCTest
 
 private final class SafeDictionaryReference {}
 
+private final class GateBoard: Board, ActivatableBoard {
+    func activate(withOption _: Any?) {}
+
+    /// Completes the gate, which is what the barrier's completion flow listens for.
+    func open() { complete(true) }
+}
+
 private final class BarrierProbeBoard: Board, ActivatableBoard {
     weak var owner: BarrierTestMotherboard?
 
@@ -202,6 +209,44 @@ class ActivatableBarrierBoardTests: XCTestCase {
 
     override func tearDownWithError() throws {}
 
+    // MARK: - Flow accumulation
+
+    /// A barrier board registers a completion flow on its owner and removes itself when the gate
+    /// completes — but nothing removes that flow. Reopening the same gate builds a new barrier
+    /// board, which registers the flow again.
+    ///
+    /// The stale handlers are `[weak self]` so they do nothing, but `board(_:didSendData:)` filters
+    /// every flow on every message, so the cost is permanent and grows with each cycle.
+    func testRepeatedBarrierCyclesDoNotAccumulateFlows() {
+        let target = BarrierTargetBoard(
+            identifier: "target",
+            barrierDestination: "gate",
+            barrierScope: .mainboard
+        )
+        let motherboard = Motherboard(boards: [target])
+        let baseline = motherboard.flows.count
+
+        for round in 0 ..< 5 {
+            let gate = GateBoard(identifier: "gate")
+            motherboard.installBoard(gate)
+
+            motherboard.activateBoard(identifier: "target", withOption: "round-\(round)")
+            XCTAssertTrue(
+                motherboard.boards.contains { $0 is ActivatableBarrierBoard },
+                "round \(round) should install a barrier"
+            )
+
+            gate.open()
+        }
+
+        XCTAssertEqual(target.activatedValues.count, 5)
+        XCTAssertFalse(motherboard.boards.contains { $0 is ActivatableBarrierBoard })
+        XCTAssertEqual(
+            motherboard.flows.count, baseline,
+            "each completed barrier must take its completion flow with it"
+        )
+    }
+
     func testSafeDictionaryValueOrInsertReturnsOneSharedReference() {
         let dictionary = SafeDictionary<String, SafeDictionaryReference>()
         let resultLock = NSLock()
@@ -374,11 +419,12 @@ class ActivatableBarrierBoardTests: XCTestCase {
             option: .void
         ).barrierIdentifier
 
+        let flowsBeforeBarrierA = managerA.flows.count
         managerA.activateBoard(identifier: targetA.identifier, withOption: "a")
         guard let barrier = managerA.boards.first(where: { $0.identifier == barrierID }) else {
             return XCTFail("Expected the application barrier to be installed in owner A")
         }
-        let flowCountA = managerA.flows.count
+        XCTAssertEqual(managerA.flows.count, flowsBeforeBarrierA + 1, "the barrier registers one completion flow")
 
         managerB.activateBoard(identifier: coalescedB.identifier, withOption: "b-coalesced")
         XCTAssertNil(managerB.boards.first(where: { $0.identifier == barrierID }))
@@ -417,7 +463,11 @@ class ActivatableBarrierBoardTests: XCTestCase {
         XCTAssertTrue(barrier.delegate === managerB)
         XCTAssertEqual(managerA.installCounts[barrierID], 1)
         XCTAssertEqual(managerB.installCounts[barrierID], 1)
-        XCTAssertEqual(managerA.flows.count, flowCountA)
+        // Owner A no longer hosts the barrier, so it must not keep listening for the gate either.
+        // This used to assert the count was unchanged, which pinned the leak in place: the flow
+        // outlived every barrier that registered it.
+        XCTAssertEqual(managerA.flows.count, flowsBeforeBarrierA,
+                       "the completion flow must leave owner A along with the barrier")
         XCTAssertEqual(managerB.barrierActivationCount, 1)
         XCTAssertEqual(managerA.duplicateInstallAttempts + managerB.duplicateInstallAttempts, 0)
 

--- a/Example/Tests/FlowTests.swift
+++ b/Example/Tests/FlowTests.swift
@@ -199,6 +199,69 @@ final class FlowTests: XCTestCase {
         waitForExpectations(timeout: hangGuardTimeout, handler: nil)
         XCTAssertEqual(result, Action.ok)
     }
+
+    // MARK: - Bus re-entrancy
+
+    /// `transport` iterated the stored cable array directly while `connect` appended to it, so a
+    /// handler that connected to the same bus tripped Swift's exclusivity check:
+    /// "Simultaneous accesses to ..., but modification requires exclusive access".
+    ///
+    /// Fanning out to a newly connected target from inside a handler is an ordinary thing to do,
+    /// and `Bus` is fully public.
+    func testBusHandlerCanConnectToTheSameBus() {
+        let bus = Bus<String>()
+        var received: [String] = []
+
+        bus.connect(BusCable<String> { value in
+            received.append("first:\(value)")
+            if value == "one" {
+                bus.connect(BusCable<String> { later in
+                    received.append("second:\(later)")
+                })
+            }
+        })
+
+        bus.transport(input: "one")
+        bus.transport(input: "two")
+
+        // The cable added mid-transport takes effect from the next transport, not retroactively.
+        XCTAssertEqual(received, ["first:one", "first:two", "second:two"])
+    }
+
+    /// A handler that invalidates its own cable must not disturb the transport in progress.
+    func testBusHandlerCanInvalidateItsOwnCableDuringTransport() {
+        let bus = Bus<String>()
+        var received: [String] = []
+
+        let once = BusCable<String> { received.append("once:\($0)") }
+        bus.connect(once)
+        bus.connect(BusCable<String> { value in
+            received.append("always:\(value)")
+            once.invalidate()
+        })
+
+        bus.transport(input: "one")
+        bus.transport(input: "two")
+
+        XCTAssertEqual(received, ["once:one", "always:one", "always:two"])
+    }
+
+    /// Re-entering `transport` from a handler must not trap either.
+    func testBusHandlerCanReenterTransport() {
+        let bus = Bus<String>()
+        var received: [String] = []
+
+        bus.connect(BusCable<String> { value in
+            received.append(value)
+            if value == "outer" {
+                bus.transport(input: "inner")
+            }
+        })
+
+        bus.transport(input: "outer")
+
+        XCTAssertEqual(received, ["outer", "inner"])
+    }
 }
 
 private final class TestBoard: Board, ActivatableBoard {

--- a/Example/Tests/LifecycleTests.swift
+++ b/Example/Tests/LifecycleTests.swift
@@ -41,6 +41,32 @@ private final class LifecycleRecordingBoard: Board, DedicatedBoard {
     }
 }
 
+/// Stores a destination to a sibling on itself — the convenient shape the docs and templates
+/// encourage — so the test can check whether that shape retains the board.
+private final class DestinationHostBoard: Board, ActivatableBoard {
+    private var destination: BoardDestination?
+    private var genericDestination: BoardGenericDestination<String, String>?
+
+    func activate(withOption _: Any?) {}
+
+    func storeDestinations() {
+        destination = ioDestination("sibling")
+        genericDestination = BoardGenericDestination<String, String>(destinationID: "sibling", source: self)
+    }
+}
+
+private final class DestinationHostMotherboard: Motherboard {
+    private var destination: MainboardDestination?
+    private var genericDestination: MainboardGenericDestination<String, String, String, NoAction>?
+
+    func storeDestinations() {
+        destination = ioDestination("child")
+        genericDestination = MainboardGenericDestination(destinationID: "child", mainboard: self)
+    }
+}
+
+private enum NoAction: BoardFlowAction {}
+
 class LifecycleTests: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -62,6 +88,44 @@ class LifecycleTests: XCTestCase {
     /// This used to be the whole of `testBoardShouldBeReleasedAfterCompleted`, with the direct
     /// `complete()` call commented out — so the name promised the self-completion path while the
     /// body only ever exercised this one. The two paths are now separate tests.
+
+    // MARK: - Destination lifetime
+
+    /// Every other reference in this framework is weak — `ObjectBox`, `ContentBox`,
+    /// `BarrierOwnerToken`, `BoardProducerBox`. The destination types are the exception, and
+    /// storing one on the board it came from is the shape the templates produce.
+    func testStoredBoardDestinationDoesNotRetainItsSource() {
+        var board: DestinationHostBoard? = DestinationHostBoard(identifier: "host")
+        weak var weakBoard = board
+        board?.storeDestinations()
+
+        board = nil
+
+        XCTAssertNil(weakBoard, "a destination stored on its own source must not keep it alive")
+    }
+
+    func testStoredMainboardDestinationDoesNotRetainItsMotherboard() {
+        var motherboard: DestinationHostMotherboard? = DestinationHostMotherboard(identifier: "host")
+        weak var weakMotherboard = motherboard
+        motherboard?.storeDestinations()
+
+        motherboard = nil
+
+        XCTAssertNil(weakMotherboard, "a destination stored on its own motherboard must not keep it alive")
+    }
+
+    /// Releasing the source must make the destination inert rather than unsafe.
+    func testDestinationIsInertAfterItsSourceIsReleased() {
+        var board: DestinationHostBoard? = DestinationHostBoard(identifier: "host")
+        let destination = board!.ioDestination("sibling")
+        board = nil
+
+        // No crash, no delivery: there is nobody left to send to.
+        destination.activation(with: String.self).activate(with: "ignored")
+        destination.interaction(with: String.self).send(command: "ignored")
+        destination.completer.complete()
+    }
+
     func testBoardIsReleasedWhenCompletedBySibling() throws {
         let motherboard: FlowMotherboard = Motherboard(boards: [SingleBoard(identifier: "1"), ContiBoard(identifier: "2", motherboard: Motherboard())])
         weak var singleBoard = motherboard.boards.first { $0.identifier == "1" }


### PR DESCRIPTION
Review §P1-3, §P1-5 and §P1-6. Each premise was re-checked against the current
code before touching anything — one of the three no longer held. The public
interface is byte-identical to 1.62.0; all three changes are internal.

## §P1-3 — barrier completion flows accumulated (real, fixed)

A barrier board registers a completion flow on its owner and removes itself
when the gate completes, but nothing removed the flow. Reopening the same gate
built a fresh barrier board that registered it again.

Measured before the fix: five gate cycles took the owner from 4 flows to 9. The
stale handlers are `[weak self]` so they do nothing — but
`board(_:didSendData:)` filters every flow on every message, so a screen with a
gateway opened 500 times pays for 500 dead entries forever.

The barrier now takes its flow back off the owner when it completes, and on the
owner-mismatch recovery path.

**This changed an existing assertion.** `testApplicationBarrierKeeps…` asserted
that owner A's flow count was *unchanged* after the barrier handed off to owner
B, which pinned the leak in place rather than protecting the handoff. Owner A no
longer hosts the barrier, so it must not keep listening for the gate; the test
now asserts the flow leaves with it.

## §P1-5 — Bus re-entrancy (premise did not reproduce)

The review predicted an exclusivity trap: `transport` iterating `cables` while a
handler calls `connect`. Three tests covering exactly that — connect during
transport, invalidate during transport, re-enter transport — **all pass on the
unmodified code**. `Bus` is a class, so reading the property yields a
copy-on-write value rather than a long-term borrow, and there is no overlapping
access to trap on.

The tests stay as regression pins, and the snapshot is now explicit: the
guarantee should rest on a written decision, not on a detail of how property
access happens to work. Documented behavior: a cable connected mid-transport
starts receiving from the next transport.

## §P1-6 — destinations retained their source (real, fixed)

`BoardDestination` and `MainboardDestination` are classes built to be stored, and
the natural place to store one is the board or motherboard it came from — so the
retain cycle sat inside the shape the framework itself suggests. Every other
reference here is already weak: `ObjectBox`, `ContentBox`, `BarrierOwnerToken`,
`BoardProducerBox`.

Both now box their source weakly. Once the source is gone the destination is
inert rather than unsafe: it answers with a detached stand-in that has no
motherboard, so messages go nowhere. The stand-in deliberately avoids
`NoBoardProducer`, which answers with a `NoBoard` — that presents a "feature not
found" alert and traps in DEBUG without a context. Sending through a dead
destination should be silent, not fatal.

The transient value types (`BoardActivation`, `BoardInteraction`,
`BoardCompleter` and their mainboard counterparts) keep strong references: they
are created at the call site and used immediately, and are not the shape anyone
stores.

## Release note

§P1-6 is an observable **behavior** change even though no API changed: a
destination no longer keeps its source alive. Anything relying on that
accidentally will see a difference — though a motherboard nothing else retains
is already broken. This belongs under "Changed" in the changelog, not just
"Fixed", when the next version is cut.

109 tests, six consecutive runs with zero failures.