### PR TITLE
Make board removal detach and completion idempotent

### DIFF
--- a/Boardy/Core/BoardType/MotherboardType.swift
+++ b/Boardy/Core/BoardType/MotherboardType.swift
@@ -143,12 +143,34 @@ extension MotherboardRepresentable {
 
     public func removeBoard(withIdentifier identifier: BoardID) {
         boardyAssertMainThread()
-        assert(installedBoard(identifier: identifier) != nil, "\(String(describing: self)) \n🔥 Board with identifier \(identifier) was not in motherboard \(self).")
+
+        guard let board = installedBoard(identifier: identifier) else {
+            // Not an assertion. A board completing twice is ordinary — a success path and an
+            // error-path callback both firing, or the app calling `completer(id).complete()` while
+            // the board completes itself — and it used to trap here in DEBUG. The second removal
+            // has nothing left to do, so it does nothing.
+            #if DEBUG
+                print("⚠️ [\(String(describing: type(of: self)))] ➤ \(self.identifier)\n  [Already removed] ➤ Board \(identifier) is not installed; this completion is a no-op.")
+            #endif
+            return
+        }
+
+        // Detach before dropping the reference. A callback that still holds the board — an
+        // in-flight network completion, say — could otherwise emit output through this motherboard
+        // after the board is gone, match the flow registered for it, and drive the next board a
+        // second time. `mainboard.didSet` only reattaches boards that are still in the list.
+        board.delegate = nil
+
         mainboard.removeAll { $0.identifier == identifier }
     }
 
     public func clearActiveBoards() {
         boardyAssertMainThread()
+
+        for board in mainboard {
+            board.delegate = nil
+        }
+
         mainboard.removeAll()
     }
 }

--- a/Example/Tests/LifecycleTests.swift
+++ b/Example/Tests/LifecycleTests.swift
@@ -67,6 +67,23 @@ private final class DestinationHostMotherboard: Motherboard {
 
 private enum NoAction: BoardFlowAction {}
 
+/// Holds the completion its executor was handed, so a test can fire it after the board is gone —
+/// the shape an in-flight URLSession callback has.
+private final class DeferredCompletionBoard: Board, ActivatableBoard, GuaranteedOutputSendingBoard {
+    typealias OutputType = String
+
+    var deferredOutput: (() -> Void)?
+
+    func activate(withOption _: Any?) {
+        deferredOutput = { [weak self] in self?.sendOutput("late") }
+    }
+}
+
+private final class CountingBoard: Board, ActivatableBoard {
+    private(set) var activationCount = 0
+    func activate(withOption _: Any?) { activationCount += 1 }
+}
+
 class LifecycleTests: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -124,6 +141,65 @@ class LifecycleTests: XCTestCase {
         destination.activation(with: String.self).activate(with: "ignored")
         destination.interaction(with: String.self).send(command: "ignored")
         destination.completer.complete()
+    }
+
+    // MARK: - Terminal events
+
+    /// §P1-1. `removeBoard` dropped the board from the list but left its `delegate` pointing at the
+    /// motherboard. A callback still holding the board — an in-flight network completion, say —
+    /// could therefore emit output after the board was gone, match the flow that was registered for
+    /// it, and drive the next board a second time.
+    func testOutputFromARemovedBoardDoesNotReachTheMotherboard() {
+        let source = DeferredCompletionBoard(identifier: "source")
+        let next = CountingBoard(identifier: "next")
+        let motherboard: FlowMotherboard = Motherboard(boards: [source, next])
+        motherboard.matchedFlow("source", with: String.self).handle { [unowned motherboard] _ in
+            motherboard.activateBoard(identifier: "next", withOption: nil)
+        }
+
+        motherboard.activateBoard(identifier: "source", withOption: nil)
+        let deferredOutput = source.deferredOutput
+        XCTAssertNotNil(deferredOutput)
+
+        source.complete()
+        XCTAssertFalse(motherboard.boards.contains { $0.identifier == "source" })
+
+        // The callback finally fires, long after the board was removed.
+        deferredOutput?()
+
+        XCTAssertEqual(next.activationCount, 0, "a removed board must not still drive the flow")
+    }
+
+    /// §P1-2. A board that completes twice — success path plus an error-path callback, or an app
+    /// calling `completer(id).complete()` while the board completes itself — hit an assertion in
+    /// `removeBoard` and crashed DEBUG builds.
+    func testCompletingTwiceIsANoOpRatherThanATrap() {
+        let board = CountingBoard(identifier: "board")
+        let motherboard: FlowMotherboard = Motherboard(boards: [board])
+
+        var completions: [Bool] = []
+        motherboard.completionFlow("board").handle { completions.append($0) }
+
+        board.complete(true)
+        board.complete(true)
+
+        XCTAssertTrue(motherboard.boards.isEmpty)
+        XCTAssertEqual(completions, [true], "the second completion must not be delivered again")
+    }
+
+    /// The same, driven from the outside rather than by the board itself.
+    func testCompleterOnAnAlreadyRemovedBoardIsANoOp() {
+        let board = CountingBoard(identifier: "board")
+        let motherboard: FlowMotherboard = Motherboard(boards: [board])
+
+        var completions: [Bool] = []
+        motherboard.completionFlow("board").handle { completions.append($0) }
+
+        board.complete(true)
+        motherboard.completer("board").complete(true)
+
+        XCTAssertTrue(motherboard.boards.isEmpty)
+        XCTAssertEqual(completions, [true])
     }
 
     func testBoardIsReleasedWhenCompletedBySibling() throws {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,9 @@ passed on `macos-26` with Xcode 26.4.1, so this release has hosted evidence but 
 older runtimes/devices, N-1 Xcode and organization production support remain unclaimed. The owner is
 recorded in [`.github/CODEOWNERS`](.github/CODEOWNERS) and the private security contact in
 [`SECURITY.md`](SECURITY.md).
-CocoaPods trunk publication remains excluded; metadata, lock resolution and pod lint were verified.
+`1.61.0` was subsequently published to the CocoaPods trunk; `1.62.0` has not been. Trunk
+publication is a separate step from tagging and needs its own authority — see
+[`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md#cocoapods-publication).
 
 ## Versioning policy
 
@@ -102,7 +104,7 @@ annotations or warning suppression.
 
 For the original SPM-first candidate procedure, CocoaPods tests and `pod lib lint` were deferred;
 Boardy 1.61.0 later passed the hosted CocoaPods test/lint row on exact merge SHA
-`eba3b311b28066c604dd878f92df799d99ed06f0`. `pod trunk push` remains excluded. Always finish with
+`eba3b311b28066c604dd878f92df799d99ed06f0`. Always finish with
 `git diff --check` and `git status --short`.
 
 Retain Xcode version, destination, logs and result bundles under `.build-local/Results`. Local results
@@ -182,20 +184,19 @@ create a release from another SHA.
 
 ## 8. CocoaPods transition checklist
 
-CocoaPods trunk publication is excluded from the current execution. Do not run `pod trunk push`,
-register a trunk session or describe the candidate as available from CocoaPods 1.61.0.
+Trunk publication is a separate step from tagging, with its own authority. `1.61.0` is on the trunk;
+`1.62.0` is not. Tagging a version does not publish it, and a tag must never be moved or replaced to
+make a publication succeed.
 
-For a later, separately approved CocoaPods publication:
+For each publication:
 
 - [ ] Confirm UIComposable dependency availability and the exact Boardy pod constraint.
-- [ ] Clear the publication gate in
-      [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md#cocoapods-publication-gate): every consumer
-      depending on Boardy without a version bound below iOS 14 must raise its floor, pin `< 1.61`,
-      or record retirement.
+- [ ] Re-read [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md#cocoapods-publication) and confirm the
+      recorded consumer disposition still holds for the floor this release carries.
 - [ ] Re-resolve the Example lock, rerun the CocoaPods test row and pass `pod lib lint` from a clean
       tagged checkout.
-- [ ] Confirm the podspec source tag is the annotated public `1.61.0` tag and its peeled SHA matches the
-      reviewed release commit.
+- [ ] Confirm the podspec source tag is the annotated public tag for the version being published and
+      its peeled SHA matches the reviewed release commit.
 - [ ] Obtain explicit CocoaPods publication authority and record the release actor.
 - [ ] Publish through the approved CocoaPods process, then verify the public podspec and install it
       in a disposable consumer.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,14 +8,14 @@ policy exists, maintenance and triage are best effort and no service-level agree
 | Version | Status | Platform and evidence boundary |
 |---|---|---|
 | 1.62.0 | Current line | iOS 14+. Every push runs hosted CI on Xcode 26.4.1 / `macos-26`: build, tests, podspec lint and public-API verification against the 1.61.0 baseline. Older runtimes, other devices and N-1 Xcode remain unverified. |
-| 1.61.0 | Released, superseded by 1.62.0 | iOS 14+. Published as a Git tag; not published to the CocoaPods trunk. |
+| 1.61.0 | Released, superseded by 1.62.0 | iOS 14+. Published as a Git tag and to the CocoaPods trunk. |
 | 1.60.1 | Last CocoaPods-published line | iOS 12 floor; fixes and response times are not guaranteed. |
 | 1.60.0 and earlier | Historical | No active maintenance commitment. Use tags and commit history as the record. |
 
-The current evidence boundary is in
-[`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md). A consumer below iOS 14 must
-remain below Boardy 1.61 unless it raises its deployment target.
-Boardy is published as Git tags only; the CocoaPods trunk still serves 1.60.1.
+The current evidence boundary is in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
+
+The CocoaPods trunk serves up to 1.61.0, so a dependency without a version bound resolves it and
+inherits the iOS 14 floor. An application that must stay below iOS 14 pins `~> 1.60`.
 
 ## Where to ask
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,23 +38,17 @@ main-thread-only path and cannot be made one without changing published behavior
 therefore locked internally and every reader takes a snapshot. No caller obligation is added by
 this; sending output off the main thread was always supported and remains so.
 
-## CocoaPods publication gate
+## CocoaPods publication
 
-Boardy 1.61.0 ships as a Git tag and GitHub Release only; it is not published to the CocoaPods
-trunk. Existing pod consumers therefore do not resolve it automatically and stay on their current
-line until their own owner schedules a migration.
+Boardy 1.61.0 is published to the CocoaPods trunk. A consumer that depends on Boardy without a
+version bound resolves it and inherits the iOS 14 floor.
 
-This gate must be cleared before any later trunk publication. Every known consumer that depends on
-Boardy without a version bound and targets below iOS 14 must do one of:
+The owner's disposition: every known consumer already targets iOS 14 or newer, so this is not a
+migration event. An application that must stay below iOS 14 pins `~> 1.60`, which continues to serve
+the iOS 12 line.
 
-- raise its own deployment floor to iOS 14, or
-- add an explicit `< 1.61` ceiling on its Boardy dependency, or
-- record a retirement disposition.
-
-Unbounded dependencies below the floor were the reason publication was excluded, not an oversight.
-The Boardy owner owns this gate; application owners own their own migrations. Templates that
-generate podspecs must stop emitting unbounded Boardy dependencies before publication, or they
-reintroduce the problem for every module they scaffold.
+Templates that generate podspecs should still emit a bounded Boardy dependency; an unbounded one
+hands every scaffolded module whatever floor the newest release happens to carry.
 
 ## Compatibility policy
 


### PR DESCRIPTION
Review §P1-1 and §P1-2 — the last two source-level items. Both premises were
confirmed against the current code before changing anything. The public
interface is byte-identical to 1.62.0.

## §P1-2 — completing twice crashed DEBUG builds

`removeBoard` asserted the board was installed. A board that completes twice —
a success path plus an error-path callback, or an app calling
`completer(id).complete()` while the board completes itself — therefore trapped.

Not theoretically: the regression test for it killed the test process outright
before the fix.

```
Test Case 'testCompletingTwiceIsANoOpRatherThanATrap' started.
Restarting after unexpected exit, crash, or test timeout
```

Completing twice is ordinary, not a programming error. A second removal has
nothing left to do, so it now does nothing and says so in DEBUG.

## §P1-1 — output from a removed board still drove the flow

`removeBoard` dropped the board from the list but left its `delegate` pointing at
the motherboard, and `mainboard.didSet` only ever *adds* delegates — it never
clears one. A callback still holding the board (an in-flight network completion
being the usual case) could emit output after the board was gone, match the flow
registered for its identifier, and activate the next board a second time.
Measured before the fix: the downstream board ran once when it should not have
run at all.

Removal now detaches the board before dropping it, so a late callback has
nowhere to send. `clearActiveBoards` does the same for everything it drops.

The review also suggested a `hasCompleted` latch on the board. It is unnecessary
once the delegate is cleared — the second `complete()` cannot reach the
motherboard either — and it would need per-instance storage hung off a protocol.
Detaching is the smaller change and covers both defects.

No existing test needed changing. `BarrierTestMotherboard` asserts the barrier
keeps its delegate through the owner handoff and still passes: it conforms to
`MotherboardType` directly rather than through `MotherboardRepresentable`, so it
has its own removal path.

## Correction: the CocoaPods trunk claims in this repo were false

While assessing what remained for the library's positioning I found that 1.61.0
has been on the CocoaPods trunk since 2026-08-02 02:26 UTC. Five places said
otherwise, and three of them I wrote in the 1.62.0 release-record commit by
carrying an older claim forward without checking `pod trunk info`.

`SUPPORT.md`, `docs/COMPATIBILITY.md` and `RELEASING.md` now describe what is
actually published, and record the owner's disposition: every known consumer
already targets iOS 14 or newer, so the floor raised in 1.61.0 is not a migration
event, and anything that must stay below it pins `~> 1.60`. The "publication
gate" framing is gone — it described work to do before something that had already
happened.

## Status

This closes every P0 and P1 item from the 2026-08-01 review. Two of the six P1s
turned out not to need a code change: §P1-4's discarded activations became
diagnostics rather than a deletion, and §P1-5's predicted exclusivity trap did
not reproduce.

112 tests, six consecutive runs with no failures and no crashes.