### PR TITLE
Release 1.63.0

### DIFF
--- a/Boardy.podspec
+++ b/Boardy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Boardy"
-  s.version = "1.62.0"
+  s.version = "1.63.0"
   s.swift_version = "5.0"
   s.summary = "A modular orchestration framework for flow-driven iOS applications."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,76 @@ not strict Semantic Versioning.
 
 ## [Unreleased]
 
-No changes have been assigned beyond the 1.62.0 release.
+No changes have been assigned beyond the 1.63.0 release.
+
+## [1.63.0] - 2026-08-02
+
+Closes every P0 and P1 item from the 2026-08-01 independent review. No public
+declaration was added, removed or renamed — the captured `.swiftinterface` is
+byte-identical to 1.62.0 — but four defect fixes change observable behavior, so
+this is a minor release rather than a patch.
+
+### Fixed
+
+- A barrier board registered a completion flow on its owner and removed itself
+  when its gate completed, but nothing removed the flow. Reopening the same gate
+  registered it again. Measured: five gate cycles took an owner from 4 flows to
+  9. The stale handlers were `[weak self]` and did nothing, but every board
+  message filtered all of them, so the cost was permanent and grew per cycle.
+- A board that completed twice trapped on an assertion in `removeBoard` and
+  crashed DEBUG builds. Two callbacks both firing, or an app calling
+  `completer(id).complete()` while the board completes itself, was enough.
+- Output from a removed board still drove the flow. Removal dropped the board
+  from the list but left its `delegate` pointing at the motherboard, so an
+  in-flight callback that still held the board could emit output afterwards,
+  match the flow registered for its identifier, and activate the next board a
+  second time.
+- `BoardDestination` and `MainboardDestination` retained the board or
+  motherboard they came from. Storing a destination on its own source — the
+  shape the templates produce — was therefore a retain cycle, against the weak
+  convention every other reference in the framework already followed.
+
+### Changed
+
+These follow from the fixes above. Nothing in the public API changed, but code
+that depended on the old behavior will notice.
+
+- A removed board is detached from its motherboard. A callback that still holds
+  it can no longer send output through that motherboard; previously it could.
+- Completing a board twice is a silent no-op with a DEBUG note, where it
+  previously trapped in DEBUG and delivered the completion handler twice in
+  release.
+- A destination no longer keeps its source alive. Once the source is released
+  the destination becomes inert: messages sent through it go nowhere rather than
+  reaching a resurrected object.
+- `Bus.transport` documents what it already did: a cable connected from inside a
+  handler starts receiving from the next transport, not the current one. The
+  iteration snapshot is now explicit rather than incidental.
+
+### Added
+
+- Tests: 73 to 112. All ten `registerCombinedFlow` overloads (one was covered),
+  the `Composable` subsystem (nothing was covered), and `Bus` re-entrancy.
+  Coverage 55.45% to 65.91%.
+- Documentation on 37 entry-point types and a `Boardy.docc` catalog with a
+  landing page and topic groups. `xcodebuild docbuild` succeeds; SwiftPM picks
+  the catalog up and CocoaPods ignores it.
+
+### Testing
+
+- The suite no longer measures time. Nine mocks delayed their output by a literal
+  second to be asynchronous while tests raced that delay against a 1–6 second
+  timeout; two of them failed the 1.62.0 release on code that had already passed.
+  Delays became plain `async` and every remaining timeout is one generous
+  deadlock guard. Full suite: 9.75s to 0.34s.
+- Three tests that asserted nothing were rewritten to assert something.
+
+### Documentation
+
+- Corrected the CocoaPods trunk statements. 1.61.0 has been on the trunk since
+  2026-08-02; five places in this repository said it had not been published. A
+  dependency without a version bound resolves it and inherits the iOS 14 floor;
+  anything that must stay below that pins `~> 1.60`.
 
 ## [1.62.0] - 2026-08-02
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,24 +5,24 @@ PODS:
     - Authentication
     - Boardy/ModulePlugin
     - SiFUtilities
-  - Boardy (1.62.0):
-    - Boardy/Default (= 1.62.0)
-  - Boardy/Attachable (1.62.0):
+  - Boardy (1.63.0):
+    - Boardy/Default (= 1.63.0)
+  - Boardy/Attachable (1.63.0):
     - Boardy/Core
-  - Boardy/ComponentKit (1.62.0):
+  - Boardy/ComponentKit (1.63.0):
     - Boardy/Core
-  - Boardy/Composable (1.62.0):
+  - Boardy/Composable (1.63.0):
     - Boardy/Attachable
     - UIComposable (~> 1.0.1)
-  - Boardy/Core (1.62.0):
+  - Boardy/Core (1.63.0):
     - UIComposable (~> 1.0.1)
-  - Boardy/Default (1.62.0):
+  - Boardy/Default (1.63.0):
     - Boardy/Attachable
     - Boardy/ComponentKit
     - Boardy/Composable
     - Boardy/Core
     - Boardy/ModulePlugin
-  - Boardy/ModulePlugin (1.62.0):
+  - Boardy/ModulePlugin (1.63.0):
     - Boardy/Attachable
   - Dashboard (0.1.0):
     - Boardy
@@ -137,7 +137,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Authentication: d87578c03865995057e0951fc4bbc386236edf9d
   AuthenticationPlugins: dbc14cded27c507a4e160d81d8561b86ab36ff08
-  Boardy: 38107208dc34c4163c85c60bb1038a927216f9d6
+  Boardy: ce414e7aef8c11b0ec619e4792241bf08bb193b9
   Dashboard: 6e9b7ad513f594514f4b8ee3118db5da41a572d4
   DashboardPlugins: 89dcf3a1cfdae0345f6977fe80b1ae2b470363bd
   DiffableDataSources: 1ddde2de1978cc02619b2c3bfafab20e68b57279

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,9 @@ window. Reports and fixes follow this best-effort boundary:
 
 | Version | Security status |
 | --- | --- |
-| `1.62.x` | Current line; fixes land here |
-| `1.61.x` | Superseded; report against it, but expect the fix on 1.62.x |
+| `1.63.x` | Current line; fixes land here |
+| `1.62.x` | Superseded; report against it, but expect the fix on 1.63.x |
+| `1.61.x` | Superseded |
 | `1.60.1` | Last line published to the CocoaPods trunk; best effort only |
 | `1.60.0` and earlier | Unsupported |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,8 +7,9 @@ policy exists, maintenance and triage are best effort and no service-level agree
 
 | Version | Status | Platform and evidence boundary |
 |---|---|---|
-| 1.62.0 | Current line | iOS 14+. Every push runs hosted CI on Xcode 26.4.1 / `macos-26`: build, tests, podspec lint and public-API verification against the 1.61.0 baseline. Older runtimes, other devices and N-1 Xcode remain unverified. |
-| 1.61.0 | Released, superseded by 1.62.0 | iOS 14+. Published as a Git tag and to the CocoaPods trunk. |
+| 1.63.0 | Current line | iOS 14+. Every push runs hosted CI on Xcode 26.4.1 / `macos-26`: build, tests, podspec lint and public-API verification. Older runtimes, other devices and N-1 Xcode remain unverified. |
+| 1.62.0 | Released, superseded by 1.63.0 | iOS 14+. Git tag only. |
+| 1.61.0 | Released | iOS 14+. Published as a Git tag and to the CocoaPods trunk. |
 | 1.60.1 | Last CocoaPods-published line | iOS 12 floor; fixes and response times are not guaranteed. |
 | 1.60.0 and earlier | Historical | No active maintenance commitment. Use tags and commit history as the record. |
 

--- a/docs/API_STABILITY_1X.md
+++ b/docs/API_STABILITY_1X.md
@@ -1,6 +1,6 @@
 # Boardy 1.x API stability policy
 
-Applies to Boardy 1.61.0 and later supported 1.x releases. Current line: 1.62.0.
+Applies to Boardy 1.61.0 and later supported 1.x releases. Current line: 1.63.0.
 
 ## Positioning
 
@@ -15,8 +15,9 @@ Boardy 1.x is a legacy-compatible modular orchestration framework with typed inp
 
 The immutable baseline artifacts are the textual interfaces:
 
-- [`api/Boardy-1.62.0.swiftinterface`](api/Boardy-1.62.0.swiftinterface) — the **active** baseline;
-  every candidate is verified against the latest released line
+- [`api/Boardy-1.62.0.swiftinterface`](api/Boardy-1.62.0.swiftinterface) — the **active** baseline.
+  1.63.0 captures a byte-identical interface, so it adds no file of its own: a third identical copy
+  would be filing, not evidence
 - [`api/Boardy-1.61.0.swiftinterface`](api/Boardy-1.61.0.swiftinterface) — previous released line
 - [`api/Boardy-1.60.1.swiftinterface`](api/Boardy-1.60.1.swiftinterface) — retained for provenance
   and for re-running the 1.60.1 → 1.61.0 comparison on demand
@@ -44,7 +45,7 @@ Source/API removals still require a major-update decision. The platform exceptio
 
 ## Concurrency policy for 1.61.0 and later 1.x
 
-Restated for 1.62.0 unchanged, with two clarifications the 1.62.0 work made necessary.
+Unchanged since 1.61.0, with two clarifications the 1.62.0 work made necessary.
 
 **Flow dispatch is not a main-thread path, and cannot be made one.** The DEBUG main-thread
 assertion covers *mutation* of Motherboard storage. It deliberately does not cover
@@ -66,7 +67,7 @@ prevented. Changing that requires the deferred isolation plan, not a point fix.
 |---|---|---|---|
 | `GatewayBarrierRegistration` zero-width-space `exempt` | 1.61.0 | `exempt` | Requires a major update |
 
-No declaration was deprecated in 1.62.0. `ContinuousBoard` is documented as legacy and emits a DEBUG
+No declaration has been deprecated since 1.61.0. `ContinuousBoard` is documented as legacy and emits a DEBUG
 signpost, but carries no deprecation attribute: migrating to `ModernContinuableBoard` changes how the
 board is constructed, not just which type is named, so a compiler warning would push callers toward a
 change they cannot make mechanically.

--- a/docs/api/BASELINE_PROVENANCE.md
+++ b/docs/api/BASELINE_PROVENANCE.md
@@ -9,6 +9,13 @@ This directory holds the immutable textual baselines used to verify source compa
 | `Boardy-1.61.0.swiftinterface` | Previous released line; retained as the release record. | `21ff72a7fd1c4eb0062aac23c0d4d9748c37a9b39fe1e5abbd64e4dc6d9ee85a` |
 | `Boardy-1.60.1.swiftinterface` | Retained for provenance and for re-running the 1.60.1 → 1.61.0 comparison. | `a29d4bb97a6214d477c3fa739366616d911393a2d557c5d4d62c69c834454bb9` |
 
+## Why 1.63.0 has no file here
+
+1.63.0 fixes defects and changes observable behavior but touches no declaration, so its captured
+interface is byte-identical to 1.62.0's. The active baseline therefore stays at 1.62.0 rather than
+gaining a third identical copy. Verification is unaffected: comparing 1.63.0 against 1.62.0 is
+comparing it against its own surface, which is exactly what "no API change" means.
+
 ## 1.62.0 capture
 
 Taken from the `api-verify` artifact of the CI run on the tagged commit

--- a/memory/release-1-61-status.md
+++ b/memory/release-1-61-status.md
@@ -1,0 +1,11 @@
+---
+name: release-1-61-status
+description: Boardy 1.61.0 release status and evidence boundary
+metadata:
+  type: project
+---
+
+Boardy 1.61.0 merged through PR #10 at `eba3b311b28066c604dd878f92df799d99ed06f0`, with annotated remote tag `1.61.0` peeling to that merge SHA. Hosted CI run `30728752451` passed on `macos-26` with Xcode 26.4.1, including build/test and CocoaPods lint. CocoaPods trunk publication, signed release, SBOM/provenance, older runtime/device evidence, N-1 Xcode evidence, and organization production support remain deferred. GitHub Release API returned 404 for tag `1.61.0` on 2026-08-02; do not claim release-object publication until verified.
+
+**Why:** Release and plan status must distinguish annotated tag, hosted CI, and GitHub Release object.
+**How to apply:** Keep `CHANGELOG.md`, `RELEASING.md`, `docs/BOARDY_LIVING_ROADMAP.md`, and Option A plan aligned with verified remote evidence.


### PR DESCRIPTION
Version metadata and changelog for 1.63.0. No source change — the code shipped in
PR #12, #13 and #14.

**Minor, not patch.** No declaration was added, removed or renamed and the
captured `.swiftinterface` is byte-identical to 1.62.0, but four defect fixes
change observable behavior. Those are listed under "Changed", not buried under
"Fixed":

- a removed board is detached, so a late callback can no longer drive the flow
- completing twice is a no-op instead of a DEBUG trap
- a destination no longer keeps its source alive
- `Bus.transport` documents the snapshot it already took

**No new baseline file.** 1.63.0's interface is identical to 1.62.0's, so the
active baseline stays there rather than gaining a third identical copy —
comparing 1.63.0 against 1.62.0 is comparing it against its own surface, which
is exactly what "no API change" means. `docs/api/BASELINE_PROVENANCE.md` records
that so the absence does not read as an oversight.

Verified at 1.63.0: 112 tests, SPM iOS-simulator build, `pod lib lint` passed
validation, `Example/Podfile.lock` synced.