### PR TITLE
release: 1.63.1 — documentation and verified feature coverage

### DIFF
--- a/Boardy.podspec
+++ b/Boardy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Boardy"
-  s.version = "1.63.0"
+  s.version = "1.63.1"
   s.swift_version = "5.0"
   s.summary = "A modular orchestration framework for flow-driven iOS applications."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,59 @@ not strict Semantic Versioning.
 
 ## [Unreleased]
 
-No changes have been assigned beyond the 1.63.0 release.
+No changes have been assigned beyond the 1.63.1 release.
+
+## [1.63.1] - 2026-08-03
+
+Documentation and test coverage. **No shipped code changed** — a consumer already
+on 1.63.0 is running byte-identical library code, and the captured
+`.swiftinterface` is again identical to 1.62.0's. This release exists to record a
+verification milestone, not to deliver a fix. It is a Git tag only; there is
+nothing on the CocoaPods trunk to wait for.
+
+### Verified
+
+Every feature the documentation commits to now has a test asserting the contract
+as written. The suite went from 112 tests to **189** and line coverage from
+65.43% to **73.50%**, but the number that matters is that nine files which had
+executed almost no lines are now covered — `GatewayBarrierRegistration.swift`
+and `ServiceMap.swift` at 100%, `BoardFlow.swift` at 98.73%, `Flow.swift` at
+98.28%, `ActivatableBarrierBoard.swift` at 92.79%, `AlertBoard.swift` at 91.84%,
+`MotherboardType+Activate.swift` at 86.92%, `FLow+Variadic.swift` at 84.62% and
+`FlowBoard.swift` at 66.67%.
+
+The conditional gateway barrier, its three bypass routes, `FlowBoard`,
+`AlertBoard`, `ServiceMap`, `registerBoards`, nested-flow scoping through
+`mountContinuousMotherboard` and `attachContinuousMotherboard`, the flow
+primitives the Example app already relied on, the four uncovered flow-
+registration overloads and the `bindToBus:` / `sendOutputThrough:` composition
+primitives are all now pinned by tests.
+
+Four behaviours turned out to be correct but undocumented, so nothing held them
+in place. All four are now asserted by a test, and none of them changed:
+
+- `getGatewayBoard` installs two boards — the gateway and a private activation
+  barrier — and resolving the gate retires both.
+- `ObjectBox` stores a class weakly and a value type strongly, and every
+  `target:` overload routes through it. `bindToBus:` therefore does not keep the
+  caller's `Bus` alive: a `Bus` constructed inline at the registration site
+  delivers nothing, with no error and no warning.
+- `complete()` asks for the board's removal as it fires, so a completion flow
+  reports once per board.
+- `FlowBoard.allowBypassGatewayBarrier` defaults to `true`, so a `FlowBoard`
+  bypasses the gateway barrier unless told otherwise.
+
+### Changed
+
+- `ServiceMap`'s doc comment carried two descriptions of the same type, one
+  appended above the other. Reduced to one.
+- The DocC landing page showed `rootViewController.show(screen)`, which is a
+  SiFUtilities extension rather than UIKit — the same defect the independent
+  review had filed against the README. Corrected to
+  `show(screen, sender: nil)`.
+- `README.md` gained an introduction section and links to
+  `docs/Introducing Boardy.md`; the "Microservices" positioning was retired in
+  favour of claims the code supports.
 
 ## [1.63.0] - 2026-08-02
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,24 +5,24 @@ PODS:
     - Authentication
     - Boardy/ModulePlugin
     - SiFUtilities
-  - Boardy (1.63.0):
-    - Boardy/Default (= 1.63.0)
-  - Boardy/Attachable (1.63.0):
+  - Boardy (1.63.1):
+    - Boardy/Default (= 1.63.1)
+  - Boardy/Attachable (1.63.1):
     - Boardy/Core
-  - Boardy/ComponentKit (1.63.0):
+  - Boardy/ComponentKit (1.63.1):
     - Boardy/Core
-  - Boardy/Composable (1.63.0):
+  - Boardy/Composable (1.63.1):
     - Boardy/Attachable
     - UIComposable (~> 1.0.1)
-  - Boardy/Core (1.63.0):
+  - Boardy/Core (1.63.1):
     - UIComposable (~> 1.0.1)
-  - Boardy/Default (1.63.0):
+  - Boardy/Default (1.63.1):
     - Boardy/Attachable
     - Boardy/ComponentKit
     - Boardy/Composable
     - Boardy/Core
     - Boardy/ModulePlugin
-  - Boardy/ModulePlugin (1.63.0):
+  - Boardy/ModulePlugin (1.63.1):
     - Boardy/Attachable
   - Dashboard (0.1.0):
     - Boardy
@@ -137,7 +137,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Authentication: d87578c03865995057e0951fc4bbc386236edf9d
   AuthenticationPlugins: dbc14cded27c507a4e160d81d8561b86ab36ff08
-  Boardy: ce414e7aef8c11b0ec619e4792241bf08bb193b9
+  Boardy: 8a5f0989105df99fe58ca7917fd0f66c41b2b1bd
   Dashboard: 6e9b7ad513f594514f4b8ee3118db5da41a572d4
   DashboardPlugins: 89dcf3a1cfdae0345f6977fe80b1ae2b470363bd
   DiffableDataSources: 1ddde2de1978cc02619b2c3bfafab20e68b57279

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ nothing but a shared contract, and are therefore interchangeable.
 
 ## Installation
 
-Boardy 1.63.0 targets iOS 14+ and Swift 5 language mode.
+Boardy 1.63.1 targets iOS 14+ and Swift 5 language mode.
 
 ### Swift Package Manager (recommended)
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/congncif/boardy.git", from: "1.63.0")
+    .package(url: "https://github.com/congncif/boardy.git", from: "1.63.1")
 ]
 ```
 
@@ -74,8 +74,9 @@ the exact `UIComposableCore` 1.1.0 dependency and does not pull in the legacy Di
 pod 'Boardy'
 ```
 
-The trunk serves 1.63.0. Note that 1.62.0 was never published there, so a pod consumer moves from
-1.61.0 straight to 1.63.0 — the changelog for both applies.
+The trunk serves 1.63.0. 1.63.1 is a Git tag only; it changes no code a pod consumer runs, so
+there is nothing on the trunk to wait for. Note that 1.62.0 was never published there either, so a
+pod consumer moves from 1.61.0 straight to 1.63.0 — the changelog for both applies.
 
 A dependency without a version bound inherits whatever floor the resolved version carries; 1.61.0
 raised it from iOS 12 to iOS 14. An app that must stay below iOS 14 pins `~> 1.60`. See

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,8 +9,9 @@ passed on `macos-26` with Xcode 26.4.1, so this release has hosted evidence but 
 older runtimes/devices, N-1 Xcode and organization production support remain unclaimed. The owner is
 recorded in [`.github/CODEOWNERS`](.github/CODEOWNERS) and the private security contact in
 [`SECURITY.md`](SECURITY.md).
-`1.61.0` and `1.63.0` are published to the CocoaPods trunk; `1.62.0` was skipped. Trunk publication
-is a separate step from tagging and needs its own authority — see
+`1.61.0` and `1.63.0` are published to the CocoaPods trunk; `1.62.0` was skipped, and `1.63.1` ships
+no code change so it stands as a tag only. Trunk publication is a separate step from tagging and
+needs its own authority — see
 [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md#cocoapods-publication).
 
 ## Versioning policy
@@ -185,8 +186,8 @@ create a release from another SHA.
 ## 8. CocoaPods transition checklist
 
 Trunk publication is a separate step from tagging, with its own authority. `1.61.0` and `1.63.0` are
-on the trunk; `1.62.0` was skipped. Tagging a version does not publish it, and a tag must never be
-moved or replaced to make a publication succeed.
+on the trunk; `1.62.0` was skipped and `1.63.1` carries no shipped-code change. Tagging a version
+does not publish it, and a tag must never be moved or replaced to make a publication succeed.
 
 A skipped version is fine — trunk history need not be contiguous — but the changelog must let a pod
 consumer see what they are jumping over.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,8 @@ policy exists, maintenance and triage are best effort and no service-level agree
 
 | Version | Status | Platform and evidence boundary |
 |---|---|---|
-| 1.63.0 | Current line; on the CocoaPods trunk | iOS 14+. Every push runs hosted CI on Xcode 26.4.1 / `macos-26`: build, tests, podspec lint and public-API verification. Older runtimes, other devices and N-1 Xcode remain unverified. |
+| 1.63.1 | Current line; Git tag only | iOS 14+. Documentation and test-suite release: no shipped code changed, so a consumer on 1.63.0 is running identical library code. |
+| 1.63.0 | On the CocoaPods trunk | iOS 14+. Every push runs hosted CI on Xcode 26.4.1 / `macos-26`: build, tests, podspec lint and public-API verification. Older runtimes, other devices and N-1 Xcode remain unverified. |
 | 1.62.0 | Released, superseded by 1.63.0 | iOS 14+. Git tag only — never published to the CocoaPods trunk. |
 | 1.61.0 | Released | iOS 14+. Published as a Git tag and to the CocoaPods trunk. |
 | 1.60.1 | Last line with an iOS 12 floor | On the CocoaPods trunk; pin `~> 1.60` to stay here. Fixes and response times are not guaranteed. |
@@ -16,7 +17,8 @@ policy exists, maintenance and triage are best effort and no service-level agree
 The current evidence boundary is in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 
 The CocoaPods trunk serves up to 1.63.0, so a dependency without a version bound resolves it and
-inherits the iOS 14 floor. An application that must stay below iOS 14 pins `~> 1.60`. 1.62.0 was
+inherits the iOS 14 floor. 1.63.1 is not on the trunk and does not need to be: it changes no shipped
+code. An application that must stay below iOS 14 pins `~> 1.60`. 1.62.0 was
 skipped on the trunk, so a pod consumer moving from 1.61.0 lands on 1.63.0 and takes both changelogs
 at once.
 

--- a/docs/API_STABILITY_1X.md
+++ b/docs/API_STABILITY_1X.md
@@ -1,6 +1,6 @@
 # Boardy 1.x API stability policy
 
-Applies to Boardy 1.61.0 and later supported 1.x releases. Current line: 1.63.0.
+Applies to Boardy 1.61.0 and later supported 1.x releases. Current line: 1.63.1.
 
 ## Positioning
 
@@ -16,8 +16,8 @@ Boardy 1.x is a legacy-compatible modular orchestration framework with typed inp
 The immutable baseline artifacts are the textual interfaces:
 
 - [`api/Boardy-1.62.0.swiftinterface`](api/Boardy-1.62.0.swiftinterface) — the **active** baseline.
-  1.63.0 captures a byte-identical interface, so it adds no file of its own: a third identical copy
-  would be filing, not evidence
+  1.63.0 and 1.63.1 both capture a byte-identical interface, so neither adds a file of its own:
+  further identical copies would be filing, not evidence
 - [`api/Boardy-1.61.0.swiftinterface`](api/Boardy-1.61.0.swiftinterface) — previous released line
 - [`api/Boardy-1.60.1.swiftinterface`](api/Boardy-1.60.1.swiftinterface) — retained for provenance
   and for re-running the 1.60.1 → 1.61.0 comparison on demand

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -40,8 +40,9 @@ this; sending output off the main thread was always supported and remains so.
 
 ## CocoaPods publication
 
-Boardy 1.61.0 and 1.63.0 are published to the CocoaPods trunk; 1.62.0 was skipped. A consumer that
-depends on Boardy without a version bound resolves 1.63.0 and inherits the iOS 14 floor.
+Boardy 1.61.0 and 1.63.0 are published to the CocoaPods trunk; 1.62.0 was skipped, and 1.63.1
+changes no shipped code so it stands as a tag only. A consumer that depends on Boardy without a
+version bound resolves 1.63.0 and inherits the iOS 14 floor.
 
 The owner's disposition: every known consumer already targets iOS 14 or newer, so this is not a
 migration event. An application that must stay below iOS 14 pins `~> 1.60`, which continues to serve

--- a/docs/Introducing Boardy.md
+++ b/docs/Introducing Boardy.md
@@ -156,7 +156,7 @@ The cast still happens underneath. Nobody chose the type twice, which is what ma
 
 ## Where it stands
 
-Version 1.63.0. Every push runs hosted CI: build, the full test suite, podspec lint, and a
+Version 1.63.1. Every push runs hosted CI: build, the full test suite, podspec lint, and a
 public-API check that fails on a removed or renamed declaration.
 
 The lifecycle behavior is the part that was hardened most recently. Completing a board twice is a

--- a/docs/api/BASELINE_PROVENANCE.md
+++ b/docs/api/BASELINE_PROVENANCE.md
@@ -9,12 +9,16 @@ This directory holds the immutable textual baselines used to verify source compa
 | `Boardy-1.61.0.swiftinterface` | Previous released line; retained as the release record. | `21ff72a7fd1c4eb0062aac23c0d4d9748c37a9b39fe1e5abbd64e4dc6d9ee85a` |
 | `Boardy-1.60.1.swiftinterface` | Retained for provenance and for re-running the 1.60.1 → 1.61.0 comparison. | `a29d4bb97a6214d477c3fa739366616d911393a2d557c5d4d62c69c834454bb9` |
 
-## Why 1.63.0 has no file here
+## Why 1.63.0 and 1.63.1 have no file here
 
 1.63.0 fixes defects and changes observable behavior but touches no declaration, so its captured
 interface is byte-identical to 1.62.0's. The active baseline therefore stays at 1.62.0 rather than
 gaining a third identical copy. Verification is unaffected: comparing 1.63.0 against 1.62.0 is
 comparing it against its own surface, which is exactly what "no API change" means.
+
+1.63.1 is documentation and tests only. A `.swiftinterface` carries no doc comments, so the two
+changed doc comments in shipped source cannot reach the captured surface — the interface is again
+byte-identical to 1.62.0's and the baseline is unchanged for the same reason.
 
 ## 1.62.0 capture
 


### PR DESCRIPTION
## Đây là release loại gì

**Patch.** Không một dòng code được ship nào đổi. Consumer đang ở 1.63.0 chạy library **byte-identical**; `.swiftinterface` chụp lại vẫn giống 1.62.0. Release này ghi một mốc kiểm chứng, không sửa lỗi gì.

Vì sao vẫn là patch chứ không phải minor: theo `docs/API_STABILITY_1X.md`, minor dành cho thay đổi hành vi quan sát được hoặc nâng sàn platform. Ở đây không có cả hai.

## Trạng thái trunk giữ nguyên sự thật

Trunk vẫn serve **1.63.0**. Mọi câu về trunk trong `README.md`, `SUPPORT.md`, `docs/COMPATIBILITY.md`, `RELEASING.md` nói đúng cái đang được publish, không nói cái mới chỉ được tag. `pod trunk push` cần thẩm quyền riêng và không cần thiết ở đây — 1.63.1 không đổi code nào consumer chạy.

## Nội dung

| Hạng mục | Trước | Sau |
|---|---|---|
| Test | 112 | **189** |
| Coverage | 65,43% | **73,50%** |
| Tính năng tài liệu có test khẳng định hợp đồng | 0/12 | **12/12** |

Chín file trước đây gần như không chạy dòng nào giờ đã được kiểm chứng — `GatewayBarrierRegistration` và `ServiceMap` 100%, `BoardFlow` 98,73%, `Flow.swift` 98,28%, `ActivatableBarrierBoard` 92,79%, `AlertBoard` 91,84%, `MotherboardType+Activate` 86,92%, `FLow+Variadic` 84,62%, `FlowBoard` 66,67%.

Hai sửa đổi doc-only trong source được ship: doc comment `ServiceMap` bị lặp hai mô tả, và DocC sample dùng `rootViewController.show(screen)` — một extension của SiFUtilities chứ không phải UIKit, đúng defect mà review độc lập đã ghi cho README.

## Bốn hành vi đúng thiết kế nhưng chưa được ghi ở đâu

Không có gì đổi, nhưng trước đây không gì giữ chúng. Đáng chú ý nhất với consumer là điều thứ hai:

1. `getGatewayBoard` cài hai board — gateway và một activation barrier riêng — và resolve gate dọn cả hai.
2. **`ObjectBox` giữ class weak, value type strong**, và mọi overload `target:` đi qua nó. Nên `bindToBus:` **không** giữ `Bus` sống hộ caller: dựng `Bus` ngay tại chỗ đăng ký thì không delivery gì cả, không lỗi, không cảnh báo.
3. `complete()` yêu cầu gỡ board ngay khi phát, nên completion flow báo đúng một lần mỗi board.
4. `FlowBoard.allowBypassGatewayBarrier` mặc định `true`.

## Kiểm chứng cục bộ

- 189 test, 0 failure trên tree đã regenerate Pods
- `pod install --deployment` pass — đúng cái check mà lock stale sẽ fail và **cả `pod lib lint` lẫn `xcodebuild test` đều không bắt được**; đây là lỗi từng làm vỡ release 1.62.0
- `pod lib lint Boardy.podspec` → *Boardy passed validation*
- `git diff --check` sạch

## Baseline API

Giữ ở `Boardy-1.62.0.swiftinterface`, có lý do đã ghi trong `docs/api/BASELINE_PROVENANCE.md`: `.swiftinterface` **không** mang doc comment, nên hai doc comment đổi trong source được ship không thể tới bề mặt đã chụp. Thêm bản sao thứ ba là lưu trữ, không phải bằng chứng.

## Sau khi merge

Tag annotated `1.63.1` tại SHA merge (cần anh xác nhận). Trunk push: **không** làm, và cần thẩm quyền riêng nếu anh muốn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)